### PR TITLE
Replace C++11 threads with OpenMP

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -10,10 +10,6 @@ pool:
   vmImage: 'ubuntu-latest'
 strategy:
   matrix:
-    Python36:
-      python.version: '3.6'
-    Python37:
-      python.version: '3.7'
     Python38:
       python.version: '3.8'
 

--- a/pp_sketch/__init__.py
+++ b/pp_sketch/__init__.py
@@ -3,4 +3,4 @@
 
 '''PopPUNK sketching functions'''
 
-__version__ = '1.4.0'
+__version__ = '1.4.1'

--- a/pp_sketch/__main__.py
+++ b/pp_sketch/__main__.py
@@ -284,7 +284,7 @@ def main():
             query_kmers = sorted(db_kmers)
         else:
             query_kmers = sorted(set(kmers).intersection(db_kmers))
-            if (len(kmers) == 0):
+            if (len(query_kmers) == 0):
                 sys.stderr.write("No requested k-mer lengths found in DB\n")
                 sys.exit(1)
             elif (len(query_kmers) < len(query_kmers)):

--- a/src/api.cpp
+++ b/src/api.cpp
@@ -178,18 +178,7 @@ NumpyMatrix query_db(std::vector<Reference>& ref_sketches,
 
         arma::mat kmer_mat = kmer2mat<std::vector<size_t>>(kmer_lengths);
 
-        // Set OpenMP schedule
-        int collapse_level;
-        if (query_sketches.size() < num_threads) {
-            // Small numbers of queries - parallelise both query and ref
-            collapse_level = 2;
-        } else {
-            // Try to improve cache hit by giving each thread its own query
-            collapse_level = 1;
-        }
-        const int collapse = collapse_level;
-
-        #pragma omp parallel for collapse(collapse) schedule(static) num_threads(num_threads)
+        #pragma omp parallel for collapse(2) schedule(static) num_threads(num_threads)
         for (unsigned int q_idx = 0; q_idx < query_sketches.size(); q_idx++) {
             const size_t query_length = query_sketches[q_idx].seq_length();
             const uint16_t query_random_idx =

--- a/src/api.cpp
+++ b/src/api.cpp
@@ -4,9 +4,7 @@
  *
  */
 
-#include <thread>
 #include <algorithm>
-#include <queue>
 #include <limits>
 #include <sys/stat.h>
 
@@ -23,34 +21,6 @@ inline bool file_exists (const std::string& name) {
   struct stat buffer;
   return (stat (name.c_str(), &buffer) == 0);
 }
-
-// Internal function definitions
-void self_dist_block(NumpyMatrix& distMat,
-                     const std::vector<size_t>& kmer_lengths,
-                     std::vector<Reference>& sketches,
-                     const RandomMC& random_chance,
-                     const bool jaccard,
-                     const size_t start_pos,
-                     const size_t calcs);
-
-void query_dist_row(NumpyMatrix& distMat,
-                    Reference * ref_sketch_ptr,
-                    std::vector<Reference>& query_sketches,
-                    const RandomMC& random_chance,
-                    const std::vector<size_t>& kmer_lengths,
-                    const bool jaccard,
-                    const size_t row_start);
-
-void sketch_block(std::vector<Reference>& sketches,
-                                    const std::vector<std::string>& names,
-                                    const std::vector<std::vector<std::string>>& files,
-                                    const std::vector<size_t>& kmer_lengths,
-                                    const size_t sketchsize64,
-                                    const bool use_rc,
-                                    const uint8_t min_count,
-                                    const bool exact,
-                                    const size_t start,
-                                    const size_t end);
 
 
 bool same_db_version(const std::string& db1_name,
@@ -73,8 +43,7 @@ std::vector<Reference> create_sketches(const std::string& db_name,
                    const bool use_rc,
                    size_t min_count,
                    const bool exact,
-                   const size_t num_threads)
-{
+                   const size_t num_threads) {
     // Store sketches in vector
     std::vector<Reference> sketches;
 
@@ -95,49 +64,27 @@ std::vector<Reference> create_sketches(const std::string& db_name,
         sketches.resize(names.size());
 
         // Truncate min_count if above 8 bit range
-        if (min_count > std::numeric_limits<uint8_t>::max())
-        {
+        if (min_count > std::numeric_limits<uint8_t>::max()) {
             min_count = std::numeric_limits<uint8_t>::max();
         }
 
-        // Create threaded queue for distance calculations
         size_t num_sketch_threads = num_threads;
-        if (sketches.size() < num_threads)
-        {
+        if (sketches.size() < num_threads) {
             num_sketch_threads = sketches.size();
         }
-        size_t calc_per_thread = (size_t)sketches.size() / num_sketch_threads;
-        unsigned int num_big_threads = sketches.size() % num_sketch_threads;
-        std::vector<std::thread> sketch_threads;
 
-        // Spawn worker threads
-        size_t start = 0;
-        std::cerr << "Sketching " << names.size() << " genomes using " << num_sketch_threads << " thread(s)" << std::endl;
-        for (unsigned int thread_idx = 0; thread_idx < num_sketch_threads; ++thread_idx) // Loop over threads
-        {
-            // First 'big' threads have an extra job
-            size_t thread_jobs = calc_per_thread;
-            if (thread_idx < num_big_threads)
-            {
-                thread_jobs++;
-            }
-            sketch_threads.push_back(std::thread(&sketch_block,
-                                            std::ref(sketches),
-                                            std::cref(names),
-                                            std::cref(files),
-                                            std::cref(kmer_lengths),
-                                            sketchsize64,
-                                            use_rc,
-                                            min_count,
-                                            exact,
-                                            start,
-                                            start + thread_jobs));
-            start += thread_jobs;
-        }
-        // Wait for threads to complete
-        for (auto it = sketch_threads.begin(); it != sketch_threads.end(); it++)
-        {
-            it->join();
+        std::cerr << "Sketching "
+                  << names.size()
+                  << " genomes using "
+                  << num_sketch_threads
+                  << " thread(s)"
+                  << std::endl;
+
+        #pragma omp parallel for schedule(static) num_threads(num_threads)
+        for (unsigned int i = 0; i < names.size(); i++) {
+            SeqBuf seq_in(files[i], kmer_lengths.back());
+            sketches[i] = Reference(names[i], seq_in, kmer_lengths, sketchsize64,
+                                    use_rc, min_count, exact);
         }
 
         // Save sketches and check for densified sketches
@@ -172,7 +119,9 @@ NumpyMatrix query_db(std::vector<Reference>& ref_sketches,
                                  "chance; increase minimum k-mer length");
     }
 
-    std::cerr << "Calculating distances using " << num_threads << " thread(s)" << std::endl;
+    std::cerr << "Calculating distances using " << num_threads
+              << " thread(s)" << std::endl;
+
     NumpyMatrix distMat;
     size_t dist_cols;
     if (jaccard) {
@@ -189,85 +138,83 @@ NumpyMatrix query_db(std::vector<Reference>& ref_sketches,
     if (ref_sketches == query_sketches) {
 
         // calculate dists
-        size_t dist_rows = static_cast<int>(0.5*(ref_sketches.size())*(ref_sketches.size() - 1));
+        size_t dist_rows =
+         static_cast<size_t>(0.5*(ref_sketches.size())*(ref_sketches.size() - 1));
         distMat.resize(dist_rows, dist_cols);
 
-        size_t num_dist_threads = num_threads;
-        if (dist_rows < num_threads)
-        {
-            num_dist_threads = dist_rows;
-        }
-        size_t calc_per_thread = (size_t)dist_rows / num_dist_threads;
-        unsigned int num_big_threads = dist_rows % num_dist_threads;
+        arma::mat kmer_mat = kmer2mat<std::vector<size_t>>(kmer_lengths);
 
-        // Loop over threads
-        std::vector<std::thread> dist_threads;
-        size_t start = 0;
-        for (unsigned int thread_idx = 0; thread_idx < num_dist_threads; ++thread_idx)
-        {
-            // First 'big' threads have an extra job
-            size_t thread_jobs = calc_per_thread;
-            if (thread_idx < num_big_threads)
-            {
-                thread_jobs++;
+        // Iterate upper triangle
+        size_t done_calcs = 0;
+        #pragma omp parallel for simd schedule(guided, 1) num_threads(num_threads)
+        for (size_t i = 0; i < sketches.size(); i++) {
+            for (size_t j = i + 1; j < sketches.size(); j++) {
+                size_t pos = square_to_condensed(i, j, sketches.size());
+                if (jaccard) {
+                    for (unsigned int kmer_idx = 0; kmer_idx < kmer_lengths.size(); kmer_idx++) {
+                        distMat(pos, kmer_idx) =
+                            sketches[i].jaccard_dist(sketches[j],
+                                                     kmer_lengths[kmer_idx],
+                                                     random_chance);
+                    }
+                } else {
+                    std::tie(distMat(pos, 0), distMat(pos, 1)) =
+                        sketches[i].core_acc_dist<RandomMC>(sketches[j],
+                                                            kmer_mat,
+                                                            random_chance);
+                }
             }
-
-            dist_threads.push_back(std::thread(&self_dist_block,
-                                            std::ref(distMat),
-                                            std::cref(kmer_lengths),
-                                            std::ref(ref_sketches),
-                                            std::cref(random_chance),
-                                            jaccard,
-                                            start,
-                                            thread_jobs));
-            start += thread_jobs;
         }
-        // Wait for threads to complete
-        for (auto it = dist_threads.begin(); it != dist_threads.end(); it++)
-        {
-            it->join();
-        }
-    }
-    // If ref != query, make a thread queue, with each element one ref (see kmds.cpp in seer)
-    else
-    {
+    } else {
+        // If ref != query, make a thread queue, with each element one ref
         // calculate dists
         size_t dist_rows = ref_sketches.size() * query_sketches.size();
         distMat.resize(dist_rows, dist_cols);
 
         size_t num_dist_threads = num_threads;
-        if (dist_rows < num_threads)
-        {
+        if (dist_rows < num_threads) {
             num_dist_threads = dist_rows;
         }
 
-        // Loop over threads, one per query, with FIFO queue
-        std::queue<std::thread> dist_threads;
-        size_t row_start = 0;
-        for (auto query_it = query_sketches.begin(); query_it < query_sketches.end(); query_it++)
-        {
-            // If all threads being used, wait for one to finish
-            if (dist_threads.size() == num_dist_threads)
-            {
-                dist_threads.front().join();
-                dist_threads.pop();
-            }
+        arma::mat kmer_mat = kmer2mat<std::vector<size_t>>(kmer_lengths);
 
-            dist_threads.push(std::thread(&query_dist_row,
-                              std::ref(distMat),
-                              &(*query_it),
-                              std::ref(ref_sketches),
-                              std::cref(random_chance),
-                              std::cref(kmer_lengths),
-                              jaccard,
-                              row_start));
-            row_start += ref_sketches.size();
+        // Set OpenMP schedule
+        int collapse_level;
+        if (query_sketches.size() < num_threads) {
+            // Small numbers of queries - parallelise both query and ref
+            collapse_level = 2;
+        } else {
+            // Try to improve cache hit by giving each thread its own query
+            collapse_level = 1;
         }
-        // Wait for threads to complete
-        while(!dist_threads.empty())
-        {
-            dist_threads.front().join();
-            dist_threads.pop();
+
+        #pragma omp parallel for collapse(collapse_level) schedule(static) num_threads(num_threads)
+        for (unsigned int q_idx = 0; q_idx < query_sketches.size(); q_idx++) {
+            const size_t query_length = query_sketches[q_idx].seq_length();
+            const uint16_t query_random_idx =
+                random_chance.closest_cluster(query_sketches[q_idx]);
+            for (unsigned int r_idx = 0; r_idx < ref_sketches.size(); r_idx++) {
+                const long dist_row = q_idx * ref_sketches.size() + r_idx;
+                if (jaccard) {
+                    for (unsigned int kmer_idx = 0; kmer_idx < kmer_lengths.size(); kmer_idx++) {
+                        double jaccard_random =
+                            random_chance.random_match(ref_sketches[r_idx], query_random_idx,
+                                                        query_length, kmer_lengths[kmer_idx]);
+                        distMat(dist_row, kmer_idx) =
+                            query_sketches[q_idx].jaccard_dist(ref_sketches[r_idx],
+                                                            kmer_lengths[kmer_idx],
+                                                            jaccard_random);
+                    }
+                } else {
+                    std::vector<double> jaccard_random =
+                        random_chance.random_matches(ref_sketches[r_idx], query_random_idx,
+                                                    query_length, kmer_lengths);
+                    std::tie(distMat(dist_row, 0), distMat(dist_row, 1)) =
+                            query_sketches[q_idx].core_acc_dist<std::vector<double>>(ref_sketches[r_idx],
+                                                                                kmer_mat,
+                                                                                jaccard_random);
+                }
+            }
         }
     }
 
@@ -389,112 +336,4 @@ RandomMC get_random(const std::string& db_name,
     Database db(h5_db);
     RandomMC random = db.load_random(use_rc_default);
     return(random);
-}
-
-/*
- * Internal functions used by main exported functions above
- * Loading from file
- * Simple in thread function definitions
- */
-
-// Creates sketches
-// (run this function in a thread)
-void sketch_block(std::vector<Reference>& sketches,
-                  const std::vector<std::string>& names,
-                  const std::vector<std::vector<std::string>>& files,
-                  const std::vector<size_t>& kmer_lengths,
-                  const size_t sketchsize64,
-                  const bool use_rc,
-                  const uint8_t min_count,
-                  const bool exact,
-                  const size_t start,
-                  const size_t end) {
-    for (unsigned int i = start; i < end; i++) {
-        SeqBuf seq_in(files[i], kmer_lengths.back());
-        sketches[i] = Reference(names[i], seq_in, kmer_lengths, sketchsize64,
-                                use_rc, min_count, exact);
-    }
-}
-
-// Calculates dists self v self
-// (run this function in a thread)
-void self_dist_block(NumpyMatrix& distMat,
-                     const std::vector<size_t>& kmer_lengths,
-                     std::vector<Reference>& sketches,
-                     const RandomMC& random_chance,
-                     const bool jaccard,
-                     const size_t start_pos,
-                     const size_t calcs) {
-    arma::mat kmer_mat = kmer2mat<std::vector<size_t>>(kmer_lengths);
-    // Iterate upper triangle
-    size_t done_calcs = 0;
-    size_t pos = 0;
-    for (size_t i = 0; i < sketches.size(); i++) {
-        for (size_t j = i + 1; j < sketches.size(); j++) {
-            if (pos >= start_pos) {
-                if (jaccard) {
-                    for (unsigned int kmer_idx = 0; kmer_idx < kmer_lengths.size(); kmer_idx++) {
-                        distMat(pos, kmer_idx) =
-                            sketches[i].jaccard_dist(sketches[j],
-                                                     kmer_lengths[kmer_idx],
-                                                     random_chance);
-                    }
-                } else {
-                    std::tie(distMat(pos, 0), distMat(pos, 1)) =
-                        sketches[i].core_acc_dist<RandomMC>(sketches[j],
-                                                            kmer_mat,
-                                                            random_chance);
-                }
-                done_calcs++;
-                if (done_calcs >= calcs) {
-                    break;
-                }
-            }
-            pos++;
-        }
-        if (done_calcs >= calcs) {
-            break;
-        }
-    }
-}
-
-// Calculates dists ref v query
-// (run this function in a thread)
-void query_dist_row(NumpyMatrix& distMat,
-                    Reference * query_sketch_ptr,
-                    std::vector<Reference>& ref_sketches,
-                    const RandomMC& random_chance,
-                    const std::vector<size_t>& kmer_lengths,
-                    const bool jaccard,
-                    const size_t row_start)
-{
-    arma::mat kmer_mat = kmer2mat<std::vector<size_t>>(kmer_lengths);
-    const size_t query_length = query_sketch_ptr->seq_length();
-    const uint16_t query_random_idx =
-        random_chance.closest_cluster(*query_sketch_ptr);
-
-    size_t current_row = row_start;
-    for (auto ref_it = ref_sketches.begin(); ref_it != ref_sketches.end(); ref_it++)
-    {
-        if (jaccard) {
-            for (unsigned int kmer_idx = 0; kmer_idx < kmer_lengths.size(); kmer_idx++) {
-                double jaccard_random =
-                    random_chance.random_match(*ref_it, query_random_idx,
-                                                query_length, kmer_lengths[kmer_idx]);
-                distMat(current_row, kmer_idx) =
-                    query_sketch_ptr->jaccard_dist(*ref_it,
-                                                    kmer_lengths[kmer_idx],
-                                                    jaccard_random);
-            }
-        } else {
-            std::vector<double> jaccard_random =
-                random_chance.random_matches(*ref_it, query_random_idx,
-                                             query_length, kmer_lengths);
-            std::tie(distMat(current_row, 0), distMat(current_row, 1)) =
-                     query_sketch_ptr->core_acc_dist<std::vector<double>>(*ref_it,
-                                                                          kmer_mat,
-                                                                          jaccard_random);
-        }
-        current_row++;
-    }
 }

--- a/src/hdf5_funcs.hpp
+++ b/src/hdf5_funcs.hpp
@@ -8,9 +8,7 @@
 #include "matrix.hpp"
 
 #include "robin_hood.h"
-#include <highfive/H5Group.hpp>
-#include <highfive/H5DataSet.hpp>
-#include <highfive/H5DataSpace.hpp>
+#include <highfive/H5File.hpp>
 
 // HighFive does have support for reading/writing Eigen::Matrix
 // (and std::vector<Eigen::Matrix>) which is turned on with a compile

--- a/src/matrix.hpp
+++ b/src/matrix.hpp
@@ -16,6 +16,12 @@
 typedef Eigen::Matrix<float, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor> NumpyMatrix;
 typedef std::tuple<std::vector<long>, std::vector<long>, std::vector<float>> sparse_coo;
 
+template<class T>
+inline size_t rows_to_samples(const T& longMat);
+inline long calc_row_idx(const long long k, const long n);
+inline long calc_col_idx(const long long k, const long i, const long n);
+inline long long square_to_condensed(long i, long j, long n);
+
 NumpyMatrix long_to_square(const Eigen::VectorXf& rrDists, 
                             const Eigen::VectorXf& qrDists,
                             const Eigen::VectorXf& qqDists,

--- a/src/matrix.hpp
+++ b/src/matrix.hpp
@@ -17,10 +17,24 @@ typedef Eigen::Matrix<float, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor> Nu
 typedef std::tuple<std::vector<long>, std::vector<long>, std::vector<float>> sparse_coo;
 
 template<class T>
-inline size_t rows_to_samples(const T& longMat);
-inline long calc_row_idx(const long long k, const long n);
-inline long calc_col_idx(const long long k, const long i, const long n);
-inline long long square_to_condensed(long i, long j, long n);
+inline size_t rows_to_samples(const T& longMat) {
+    return 0.5*(1 + sqrt(1 + 8*(longMat.rows())));
+}
+
+// These are inlined partially to avoid conflicting with the cuda
+// versions which have the same prototype
+inline long calc_row_idx(const long long k, const long n) {
+	return n - 2 - floor(sqrt((double)(-8*k + 4*n*(n-1)-7))/2 - 0.5);
+}
+
+inline long calc_col_idx(const long long k, const long i, const long n) {
+	return k + i + 1 - n*(n-1)/2 + (n-i)*((n-i)-1)/2;
+}
+
+inline long long square_to_condensed(long i, long j, long n) {
+    assert(j > i);
+	return (n*i - ((i*(i+1)) >> 1) + j - 1 - i);
+}
 
 NumpyMatrix long_to_square(const Eigen::VectorXf& rrDists, 
                             const Eigen::VectorXf& qrDists,

--- a/src/matrix_ops.cpp
+++ b/src/matrix_ops.cpp
@@ -195,8 +195,8 @@ NumpyMatrix long_to_square(const Eigen::VectorXf& rrDists,
     for (size_t distIdx = 0; distIdx < rrDists.rows(); distIdx++) {
         unsigned long i = calc_row_idx(distIdx, nrrSamples);
         unsigned long j = calc_col_idx(distIdx, i, nrrSamples);
-        squareMatrix(i, j) = rrDists[distIdx];
-        squareMatrix(j, i) = rrDists[distIdx];
+        squareDists(i, j) = rrDists[distIdx];
+        squareDists(j, i) = rrDists[distIdx];
     }
 
     if (qqDists.size() > 0) {
@@ -204,8 +204,8 @@ NumpyMatrix long_to_square(const Eigen::VectorXf& rrDists,
         for (size_t distIdx = 0; distIdx < qqDists.rows(); distIdx++) {
             unsigned long i = calc_row_idx(distIdx, nqqSamples) + nrrSamples;
             unsigned long j = calc_col_idx(distIdx, i - nrrSamples, nqqSamples) + nrrSamples;
-            squareMatrix(i, j) = qqDists[distIdx];
-            squareMatrix(j, i) = qqDists[distIdx];
+            squareDists(i, j) = qqDists[distIdx];
+            squareDists(j, i) = qqDists[distIdx];
         }
     }
 
@@ -215,8 +215,8 @@ NumpyMatrix long_to_square(const Eigen::VectorXf& rrDists,
         for (size_t distIdx = 0; distIdx < qrDists.rows(); distIdx++) {
             unsigned long i = static_cast<size_t>(distIdx / (float)nqqSamples + 0.001f);
             unsigned long j = distIdx % nqqSamples + nrrSamples;
-            squareMatrix(i, j) = qrDists[distIdx];
-            squareMatrix(j, i) = qrDists[distIdx];
+            squareDists(i, j) = qrDists[distIdx];
+            squareDists(j, i) = qrDists[distIdx];
         }
     }
 

--- a/src/matrix_ops.cpp
+++ b/src/matrix_ops.cpp
@@ -7,7 +7,6 @@
 #include <vector>
 #include <numeric>
 #include <algorithm>
-#include <thread>
 #include <cstdint>
 #include <cstddef>
 #include <cmath>
@@ -51,18 +50,6 @@ inline long long square_to_condensed(long i, long j, long n) {
 	return (n*i - ((i*(i+1)) >> 1) + j - 1 - i);
 }
 
-std::tuple<size_t, unsigned int, unsigned int> 
-   jobs_per_thread(const size_t num_jobs, 
-                   const unsigned int num_threads) {
-    size_t used_threads = num_threads;
-    if (num_jobs < used_threads) {
-        used_threads = num_jobs; 
-    }
-    size_t calc_per_thread = (size_t)num_jobs / used_threads;
-    unsigned int num_big_threads = num_jobs % used_threads;
-
-    return(std::make_tuple(calc_per_thread, used_threads, num_big_threads)); 
-}
 
 //https://stackoverflow.com/a/12399290
 std::vector<size_t> sort_indexes(const Eigen::VectorXf &v) {
@@ -160,8 +147,7 @@ Eigen::VectorXf assign_threshold(const NumpyMatrix& distMat,
                                  unsigned int num_threads) {
     Eigen::VectorXf boundary_test(distMat.rows());
     
-    omp_set_num_threads(num_threads);
-    #pragma omp parallel for simd schedule(static)
+    #pragma omp parallel for simd schedule(static) num_threads(num_threads)
     for (long row_idx = 0; row_idx < distMat.rows(); row_idx++) {
         float in_tri = 0;
         if (slope == 2) {
@@ -184,7 +170,7 @@ Eigen::VectorXf assign_threshold(const NumpyMatrix& distMat,
     return(boundary_test);
 }
 
-NumpyMatrix long_to_square(const Eigen::VectorXf& rrDists, 
+NumpyMatrix long_to_square(const Eigen::VectorXf& rrDists,
                             const Eigen::VectorXf& qrDists,
                             const Eigen::VectorXf& qqDists,
                             unsigned int num_threads) {
@@ -197,7 +183,7 @@ NumpyMatrix long_to_square(const Eigen::VectorXf& rrDists,
             throw std::runtime_error("Shape of reference, query and ref vs query matrices mismatches");
         }
     }
-    
+
     // Initialise matrix and set diagonal to zero
     NumpyMatrix squareDists(nrrSamples + nqqSamples, nrrSamples + nqqSamples);
     for (size_t diag_idx = 0; diag_idx < nrrSamples + nqqSamples; diag_idx++) {
@@ -205,119 +191,36 @@ NumpyMatrix long_to_square(const Eigen::VectorXf& rrDists,
     }
 
     // Loop over threads for ref v ref square
-    size_t calc_per_thread; unsigned int used_threads; unsigned int num_big_threads; 
-    std::tie(calc_per_thread, used_threads, num_big_threads) = jobs_per_thread(rrDists.rows(), num_threads); 
-    size_t start = 0;
-    std::vector<std::thread> copy_threads;
-    for (unsigned int thread_idx = 0; thread_idx < used_threads; ++thread_idx) {
-        size_t thread_jobs = calc_per_thread;
-        if (thread_idx < num_big_threads) {
-            thread_jobs++;
-        }
-
-        copy_threads.push_back(std::thread(&square_block,
-                                        std::cref(rrDists),
-                                        std::ref(squareDists),
-                                        nrrSamples,
-                                        start,
-                                        0,
-                                        thread_jobs));
-        start += thread_jobs; 
-    }
-    // Wait for threads to complete
-    for (auto it = copy_threads.begin(); it != copy_threads.end(); it++) {
-        it->join();
+    #pragma omp parallel for simd schedule(static) num_threads(num_threads)
+    for (size_t distIdx = 0; distIdx < rrDists.rows(); distIdx++) {
+        unsigned long i = calc_row_idx(distIdx, nrrSamples);
+        unsigned long j = calc_col_idx(distIdx, i, nrrSamples);
+        squareMatrix(i, j) = rrDists[distIdx];
+        squareMatrix(j, i) = rrDists[distIdx];
     }
 
-    // Query v query block
     if (qqDists.size() > 0) {
-        std::tie(calc_per_thread, used_threads, num_big_threads) = jobs_per_thread(qqDists.rows(), num_threads); 
-        start = 0;
-        copy_threads.clear();
-        for (unsigned int thread_idx = 0; thread_idx < used_threads; ++thread_idx) {
-            size_t thread_jobs = calc_per_thread;
-            if (thread_idx < num_big_threads) {
-                thread_jobs++;
-            }
-
-            copy_threads.push_back(std::thread(&square_block,
-                                            std::cref(qqDists),
-                                            std::ref(squareDists),
-                                            nrrSamples,
-                                            start,
-                                            nrrSamples,
-                                            thread_jobs));
-            start += thread_jobs; 
-        }
-        // Wait for threads to complete
-        for (auto it = copy_threads.begin(); it != copy_threads.end(); it++) {
-            it->join();
+        #pragma omp parallel for simd schedule(static) num_threads(num_threads)
+        for (size_t distIdx = 0; distIdx < qqDists.rows(); distIdx++) {
+            unsigned long i = calc_row_idx(distIdx, nqqSamples) + nrrSamples;
+            unsigned long j = calc_col_idx(distIdx, i - nrrSamples, nqqSamples) + nrrSamples;
+            squareMatrix(i, j) = qqDists[distIdx];
+            squareMatrix(j, i) = qqDists[distIdx];
         }
     }
 
     // Query vs ref rectangles
     if (qrDists.size() > 0) {
-        std::tie(calc_per_thread, used_threads, num_big_threads) = jobs_per_thread(qrDists.rows(), num_threads); 
-        start = 0;
-        copy_threads.clear();
-        for (unsigned int thread_idx = 0; thread_idx < used_threads; ++thread_idx) {
-            size_t thread_jobs = calc_per_thread;
-            if (thread_idx < num_big_threads) {
-                thread_jobs++;
-            }
-
-            copy_threads.push_back(std::thread(&rectangle_block,
-                                            std::cref(qrDists),
-                                            std::ref(squareDists),
-                                            nrrSamples,
-                                            nqqSamples,
-                                            start,
-                                            thread_jobs));
-            start += thread_jobs; 
-        }
-        // Wait for threads to complete
-        for (auto it = copy_threads.begin(); it != copy_threads.end(); it++) {
-            it->join();
+        #pragma omp parallel for simd schedule(static) num_threads(num_threads)
+        for (size_t distIdx = 0; distIdx < qrDists.rows(); distIdx++) {
+            unsigned long i = static_cast<size_t>(distIdx / (float)nqqSamples + 0.001f);
+            unsigned long j = distIdx % nqqSamples + nrrSamples;
+            squareMatrix(i, j) = qrDists[distIdx];
+            squareMatrix(j, i) = qrDists[distIdx];
         }
     }
 
     return squareDists;
-} 
-
-void square_block(const Eigen::VectorXf& longDists,
-                  NumpyMatrix& squareMatrix,
-                  const size_t n_samples,
-                  const size_t start,
-                  const size_t offset,
-                  const size_t max_elems) {
-    unsigned long i = calc_row_idx(start, n_samples) + offset;
-    unsigned long j = calc_col_idx(start, i - offset, n_samples) + offset;
-    for (size_t distIdx = start; distIdx < start + max_elems; distIdx++) {
-        squareMatrix(i, j) = longDists[distIdx];
-        squareMatrix(j, i) = longDists[distIdx];
-        if (++j == n_samples + offset) {
-            i++;
-            j = i + 1;
-        }
-    }
-}
-
-void rectangle_block(const Eigen::VectorXf& longDists,
-                  NumpyMatrix& squareMatrix,
-                  const size_t nrrSamples,
-                  const size_t nqqSamples,
-                  const size_t start,
-                  const size_t max_elems) {
-    unsigned long i = (size_t)(start/(float)nqqSamples + 0.001f);
-    unsigned long j = start % nqqSamples + nrrSamples;
-    for (size_t distIdx = start; distIdx < start + max_elems; distIdx++) {
-        squareMatrix(i, j) = longDists[distIdx];
-        squareMatrix(j, i) = longDists[distIdx];
-        if (++j == (nrrSamples + nqqSamples)) {
-            i++;
-            j = nrrSamples;
-        }
-    }
 }
 
 Eigen::VectorXf square_to_long(const NumpyMatrix& squareDists, 

--- a/src/matrix_ops.cpp
+++ b/src/matrix_ops.cpp
@@ -30,27 +30,6 @@ void rectangle_block(const Eigen::VectorXf& longDists,
                   const size_t start,
                   const size_t max_elems);
 
-template<class T>
-inline size_t rows_to_samples(const T& longMat) {
-    return 0.5*(1 + sqrt(1 + 8*(longMat.rows())));
-}
-
-// These are inlined partially to avoid conflicting with the cuda
-// versions which have the same prototype
-inline long calc_row_idx(const long long k, const long n) {
-	return n - 2 - floor(sqrt((double)(-8*k + 4*n*(n-1)-7))/2 - 0.5);
-}
-
-inline long calc_col_idx(const long long k, const long i, const long n) {
-	return k + i + 1 - n*(n-1)/2 + (n-i)*((n-i)-1)/2;
-}
-
-inline long long square_to_condensed(long i, long j, long n) {
-    assert(j > i);
-	return (n*i - ((i*(i+1)) >> 1) + j - 1 - i);
-}
-
-
 //https://stackoverflow.com/a/12399290
 std::vector<size_t> sort_indexes(const Eigen::VectorXf &v) {
 

--- a/test/test-matrix.py
+++ b/test/test-matrix.py
@@ -7,19 +7,19 @@ try:
 except ImportError as e:
     from scipy.sparse import coo_matrix
     def sparsify(distMat, cutoff, kNN, threads):
-        sparse_coordinates = pp_sketchlib.sparsifyDists(distMat, 
-                                                        distCutoff=cutoff, 
-                                                        kNN=kNN, 
+        sparse_coordinates = pp_sketchlib.sparsifyDists(distMat,
+                                                        distCutoff=cutoff,
+                                                        kNN=kNN,
                                                         num_threads=threads)
-        sparse_scipy = coo_matrix((sparse_coordinates[2], 
-                                (sparse_coordinates[0], sparse_coordinates[1])), 
-                                shape=distMat.shape, 
+        sparse_scipy = coo_matrix((sparse_coordinates[2],
+                                (sparse_coordinates[0], sparse_coordinates[1])),
+                                shape=distMat.shape,
                                 dtype=np.float32)
-        
+
         # Mirror to fill in lower triangle
         if cutoff > 0:
-            sparse_scipy = sparse_scipy + sparse_scipy.transpose() 
-        
+            sparse_scipy = sparse_scipy + sparse_scipy.transpose()
+
         return(sparse_scipy)
 
 # Original PopPUNK function
@@ -53,15 +53,15 @@ qr_mat = np.array([10, 20, 10, 20, 10, 20, 10, 20], dtype=np.float32)
 square1 = pp_sketchlib.longToSquare(rr_mat, 2)
 square2 = pp_sketchlib.longToSquareMulti(rr_mat, qr_mat, qq_mat)
 
-square1_res = np.array([[0, 1, 2, 3], 
-                        [1, 0, 4, 5], 
-                        [2, 4, 0, 6], 
+square1_res = np.array([[0, 1, 2, 3],
+                        [1, 0, 4, 5],
+                        [2, 4, 0, 6],
                         [3, 5, 6, 0]], dtype=np.float32)
 
 
-square2_res = np.array([[0, 1, 2, 3, 10, 20], 
-                        [1, 0, 4, 5, 10, 20], 
-                        [2, 4, 0, 6, 10, 20], 
+square2_res = np.array([[0, 1, 2, 3, 10, 20],
+                        [1, 0, 4, 5, 10, 20],
+                        [2, 4, 0, 6, 10, 20],
                         [3, 5, 6, 0, 10, 20],
                         [10, 10, 10, 10, 0, 8],
                         [20, 20, 20, 20, 8, 0]], dtype=np.float32)
@@ -80,8 +80,8 @@ assign0 = pp_sketchlib.assignThreshold(distMat, 0, 0.5, 0.5, 2)
 assign1 = pp_sketchlib.assignThreshold(distMat, 1, 0.5, 0.5, 2)
 assign2 = pp_sketchlib.assignThreshold(distMat, 2, 0.5, 0.5, 2)
 
-assign0_res = withinBoundary(distMat, 0.5, 0.5, 0) 
-assign1_res = withinBoundary(distMat, 0.5, 0.5, 1) 
+assign0_res = withinBoundary(distMat, 0.5, 0.5, 0)
+assign1_res = withinBoundary(distMat, 0.5, 0.5, 1)
 assign2_res = withinBoundary(distMat, 0.5, 0.5, 2)
 
 check_res(assign0, assign0_res)


### PR DESCRIPTION
Simplifies fairly large chunks of code, and maybe more efficient, particularly for the distances. 
The long to square matrix function has also been changed, and calculates i and j every iteration rather than simply incrementing, which may be slower.

Closes #30 