### PR TITLE
Check for shared memory limit being exceeded

### DIFF
--- a/src/gpu/dist.cu
+++ b/src/gpu/dist.cu
@@ -521,7 +521,7 @@ std::vector<float> dispatchDists(
 
 		// Third argument is the size of __shared__ memory needed by a thread block
 		// This is equal to the query sketch size in bytes (at a single k-mer length)
-		CUDA_CALL(calculate_dists<<<blockCount, blockSize, sketch_size_bytes>>>
+		calculate_dists<<<blockCount, blockSize, sketch_size_bytes>>>
 			(
 				self,
 				device_arrays.ref_sketches(),
@@ -540,7 +540,7 @@ std::vector<float> dispatchDists(
 				random_strides,
 				blocks_complete,
 				use_shared
-			));
+			);
 	} else {
 		std::tie(blockSize, blockCount) =
 			getBlockSize(sketch_subsample.ref_size,
@@ -550,7 +550,7 @@ std::vector<float> dispatchDists(
 
 		// Third argument is the size of __shared__ memory needed by a thread block
 		// This is equal to the query sketch size in bytes (at a single k-mer length)
-		CUDA_CALL(calculate_dists<<<blockCount, blockSize, sketch_size_bytes>>>
+		calculate_dists<<<blockCount, blockSize, sketch_size_bytes>>>
 			(
 				self,
 				device_arrays.ref_sketches(),
@@ -569,9 +569,11 @@ std::vector<float> dispatchDists(
 				random_strides,
 				blocks_complete,
 				use_shared
-			));
+			);
 	}
 
+	// Check for error in kernel launch
+	CUDA_CALL(cudaGetLastError());
 	reportDistProgress(blocks_complete, dist_rows);
 	fprintf(stderr, "%cProgress (GPU): 100.0%%\n", 13);
 

--- a/src/gpu/dist.cu
+++ b/src/gpu/dist.cu
@@ -213,7 +213,7 @@ void calculate_dists(const bool self,
 		// coalesce both here (bin inner stride) and in jaccard (sample inner stride)
 		const uint64_t* query_ptr;
 		extern __shared__ uint64_t query_shared[];
-		int query_strides;
+		int query_bin_strides;
 		if (use_shared) {
 			size_t sketch_bins = query_strides.bbits * query_strides.sketchsize64;
 			size_t sketch_stride = query_strides.bin_stride;
@@ -223,10 +223,10 @@ void calculate_dists(const bool self,
 				}
 			}
 			query_ptr = query_shared;
-			query_strides = 1;
+			query_bin_strides = 1;
 		} else {
 			query_ptr = query_start;
-			query_strides = query_strides.bin_stride;
+			query_bin_strides = query_strides.bin_stride;
 		}
 		__syncthreads();
 
@@ -238,7 +238,7 @@ void calculate_dists(const bool self,
 											 ref_strides.sketchsize64,
 											 ref_strides.bbits,
 											 ref_strides.bin_stride,
-											 query_strides);
+											 query_bin_strides);
 
 			// Adjust for random matches
 			float jaccard_expected = random_table[kmer_idx * random_strides.kmer_stride +
@@ -443,7 +443,7 @@ std::tuple<size_t, size_t, size_t> initialise_device(const int device_id) {
 	size_t mem_free = 0; size_t mem_total = 0;
 	CUDA_CALL(cudaMemGetInfo(&mem_free, &mem_total));
 	int shared_size = 0;
-	CUDA_CALL(cudaDeviceAttr(&shared_size, cudaDevAttrMaxSharedMemoryPerBlock, device_id));
+	CUDA_CALL(cudaDeviceGetAttribute(&shared_size, cudaDevAttrMaxSharedMemoryPerBlock, device_id));
 	return(std::make_tuple(mem_free, mem_total, static_cast<size_t>(shared_size)));
 }
 

--- a/src/gpu/dist.cu
+++ b/src/gpu/dist.cu
@@ -572,8 +572,8 @@ std::vector<float> dispatchDists(
 			));
 	}
 
-	//reportDistProgress(blocks_complete, dist_rows);
-	//fprintf(stderr, "%cProgress (GPU): 100.0%%\n", 13);
+	reportDistProgress(blocks_complete, dist_rows);
+	fprintf(stderr, "%cProgress (GPU): 100.0%%\n", 13);
 
 	// Copy results back to host
 	CUDA_CALL(cudaDeviceSynchronize());

--- a/src/gpu/dist.cu
+++ b/src/gpu/dist.cu
@@ -505,7 +505,7 @@ std::vector<float> dispatchDists(
 				  << std::endl;
 		std::cerr << "Reduce sketch size to "
 				  << std::floor(64 * shared_size / (query_strides.bbits*sizeof(uint64_t)))
-				  << "or less for better performance"
+				  << " or less for better performance"
 				  << std::endl;
 		sketch_size_bytes = 0;
 		use_shared = false;

--- a/src/gpu/gpu.hpp
+++ b/src/gpu/gpu.hpp
@@ -51,10 +51,9 @@ struct ALIGN(8) SketchSlice {
 	size_t query_size;
 };
 
-// defined in cuda.cuh
-std::tuple<size_t, size_t> initialise_device(const int device_id);
-
 // defined in dist.cu
+std::tuple<size_t, size_t, size_t> initialise_device(const int device_id);
+
 std::vector<uint64_t> flatten_by_bins(
 	const std::vector<Reference>& sketches,
 	const std::vector<size_t>& kmer_lengths,
@@ -69,7 +68,7 @@ std::vector<uint64_t> flatten_by_samples(
 	SketchStrides& strides,
 	const size_t start_sample_idx,
 	const size_t end_sample_idx,
-  const int cpu_threads = 1);
+    const int cpu_threads = 1);
 
 std::vector<float> dispatchDists(
 				   std::vector<Reference>& ref_sketches,
@@ -82,7 +81,8 @@ std::vector<float> dispatchDists(
 				   const SketchSlice& sketch_subsample,
 				   const std::vector<size_t>& kmer_lengths,
 				   const bool self,
-           const int cpu_threads);
+           		   const int cpu_threads,
+                   const size_t shared_size);
 
 // Memory on device for each operation
 class DeviceMemory {

--- a/src/gpu/sketch.cu
+++ b/src/gpu/sketch.cu
@@ -465,10 +465,11 @@ std::vector<uint64_t> get_signs(DeviceReads& reads, // use seqbuf.as_square_arra
         blocks_complete
     );
 
+	CUDA_CALL(cudaGetLastError());
     reportSketchProgress(blocks_complete, k, reads.count());
 
     // Copy signs back from device
-    cudaDeviceSynchronize();
+    CUDA_CALL(cudaDeviceSynchronize());
     CUDA_CALL( cudaMemcpy(signs.data(), d_signs, nbins * sizeof(uint64_t),
                           cudaMemcpyDefault));
     CUDA_CALL( cudaFree(d_signs));


### PR DESCRIPTION
Can happen with larger sketch sizes. Checks for the device, and uses global memory if the sketch doesn't fit.
Also adds better checking that kernels launched ok, which was being blocked due to immediately entering the progress loop