### PR TITLE
Move matrix index functions into one place

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,7 +61,7 @@ __pycache__/
 env/
 build/
 develop-eggs/
-dist/
+dist/*.egg
 downloads/
 eggs/
 .eggs/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,9 +24,9 @@ ENDIF(CMAKE_COMPILER_IS_GNUCC)
 
 if(UNIX AND NOT APPLE)
     if(CMAKE_CXX_COMPILER STREQUAL "icpc")
-        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fast -xCASCADELAKE -DMKL_ILP64 -m64 -static-intel")
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fopenmp -fast -xCASCADELAKE -DMKL_ILP64 -m64 -static-intel")
     else()
-        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D__STDC_LIMIT_MACROS -D__STDC_CONSTANT_MACROS")
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fopenmp -D__STDC_LIMIT_MACROS -D__STDC_CONSTANT_MACROS")
         set(CMAKE_LD_FLAGS "${CMAKE_LDFLAGS} -Wl,--as-needed")
     endif()
 endif()
@@ -44,7 +44,7 @@ find_package(pybind11 REQUIRED)
 find_package (Eigen3 3.3 REQUIRED NO_MODULE)
 find_package(Armadillo REQUIRED)
 include_directories(${ARMADILLO_INCLUDE_DIRS})
-find_package(OpenMP) # This links system openmp if present - conda sorts out rpath but take care
+#find_package(OpenMP) # This links system openmp if present - conda sorts out rpath but take care
 
 # Define python library target
 add_library("${TARGET_NAME}" MODULE)
@@ -115,7 +115,7 @@ if(CMAKE_CUDA_COMPILER)
     #set_property(TARGET "${TARGET_NAME}" PROPERTY CUDA_ARCHITECTURES OFF)
 endif()
 target_link_libraries("${TARGET_NAME}" PRIVATE pybind11::module Eigen3::Eigen
-                                               z hdf5_cpp hdf5 openblas lapack gfortran m dl)
-if(OpenMP_CXX_FOUND)
-    target_link_libraries("${TARGET_NAME}" PRIVATE OpenMP::OpenMP_CXX)
-endif()
+                                               z hdf5_cpp hdf5 gomp openblas lapack gfortran m dl)
+#if(OpenMP_CXX_FOUND)
+#    target_link_libraries("${TARGET_NAME}" PRIVATE OpenMP::OpenMP_CXX)
+#endif()

--- a/pp_sketch/__init__.py
+++ b/pp_sketch/__init__.py
@@ -3,4 +3,4 @@
 
 '''PopPUNK sketching functions'''
 
-__version__ = '1.6.0'
+__version__ = '1.6.1'

--- a/src/Makefile
+++ b/src/Makefile
@@ -5,7 +5,7 @@ ifdef DEBUG
   CUDAFLAGS = -g -G
 else ifdef PROFILE
   CXXFLAGS+= -O2 -g -flto -fno-fat-lto-objects -fPIC -fvisibility=hidden
-  CUDAFLAGS = -O2 -g -lineinfo
+  CUDAFLAGS = -O2 -pg -lineinfo
 else
   CXXFLAGS+= -O3 -flto -fno-fat-lto-objects -fPIC -fvisibility=hidden
 endif
@@ -33,7 +33,7 @@ CUDA_LDFLAGS =-L$(LIBLOC)/lib -L${CUDA_HOME}/targets/x86_64-linux/lib/stubs -L${
 CUDAFLAGS +=-Xcompiler -fPIC -Xptxas -dlcm=ca --cudart static --relocatable-device-code=true -gencode arch=compute_70,code=sm_70 -gencode arch=compute_75,code=sm_75
 ifdef GPU
 	CXXFLAGS += -DGPU_AVAILABLE
-	CUDAFLAG += -gencode arch=compute_86,code=sm_86
+	CUDAFLAGS += -gencode arch=compute_86,code=sm_86
 	CUDA_LDFLAGS += -L/usr/local/cuda-11.1/lib64
 endif
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -40,7 +40,7 @@ endif
 PYTHON_LIB = pp_sketchlib$(shell python3-config --extension-suffix)
 
 # python specific options
-python: CPPFLAGS += -DGPU_AVAILABLE -DPYTHON_EXT -DNDEBUG -Dpp_sketchlib_EXPORTS -DVERSION_INFO=\"1.6.0\" $(shell python3 -m pybind11 --includes)
+python: CPPFLAGS += -DGPU_AVAILABLE -DPYTHON_EXT -DNDEBUG -Dpp_sketchlib_EXPORTS -DVERSION_INFO=\"1.6.1\" $(shell python3 -m pybind11 --includes)
 
 PROGRAMS=sketch_test matrix_test read_test gpu_dist_test
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,13 +1,13 @@
 
-CXXFLAGS+=-Wall -Wextra -std=c++14 -fopenmp -D__STDC_LIMIT_MACROS -D__STDC_CONSTANT_MACROS
+CXXFLAGS+=-Wall -Wextra -std=c++14 -fopenmp -D__STDC_LIMIT_MACROS -D__STDC_CONSTANT_MACROS -fPIC
 ifdef DEBUG
   CXXFLAGS+= -O0 -g
   CUDAFLAGS = -g -G
 else ifdef PROFILE
-  CXXFLAGS+= -O2 -g -flto -fno-fat-lto-objects -fPIC -fvisibility=hidden
+  CXXFLAGS+= -O2 -g -flto -fno-fat-lto-objects -fvisibility=hidden
   CUDAFLAGS = -O2 -pg -lineinfo
 else
-  CXXFLAGS+= -O3 -flto -fno-fat-lto-objects -fPIC -fvisibility=hidden
+  CXXFLAGS+= -O3 -flto -fno-fat-lto-objects -fvisibility=hidden
 endif
 
 UNAME_S := $(shell uname -s)

--- a/src/dist/matrix.hpp
+++ b/src/dist/matrix.hpp
@@ -13,40 +13,10 @@
 
 #include <Eigen/Dense>
 
+#include "matrix_idx.hpp"
+
 typedef Eigen::Matrix<float, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor> NumpyMatrix;
 typedef std::tuple<std::vector<long>, std::vector<long>, std::vector<float>> sparse_coo;
-
-template<class T>
-inline size_t rows_to_samples(const T& longMat) {
-    return 0.5*(1 + sqrt(1 + 8*(longMat.rows())));
-}
-
-#ifdef __NVCC__
-__host__ __device__
-#endif
-inline long calc_row_idx(const long long k, const long n) {
-#ifndef __CUDA_ARCH__
-	return n - 2 - floor(sqrt(static_cast<double>(-8*k + 4*n*(n-1)-7))/2 - 0.5);
-#else
-	// __ll2float_rn() casts long long to float, rounding to nearest
-	return n - 2 - floor(__dsqrt_rn(__ll2double_rz(-8*k + 4*n*(n-1)-7))/2 - 0.5);
-#endif
-}
-
-#ifdef __NVCC__
-__host__ __device__
-#endif
-inline long calc_col_idx(const long long k, const long i, const long n) {
-	return k + i + 1 - n*(n-1)/2 + (n-i)*((n-i)-1)/2;
-}
-
-#ifdef __NVCC__
-__host__ __device__
-#endif
-inline long long square_to_condensed(long i, long j, long n) {
-    assert(j > i);
-	return (n*i - ((i*(i+1)) >> 1) + j - 1 - i);
-}
 
 NumpyMatrix long_to_square(const Eigen::VectorXf& rrDists,
                             const Eigen::VectorXf& qrDists,

--- a/src/dist/matrix.hpp
+++ b/src/dist/matrix.hpp
@@ -21,27 +21,39 @@ inline size_t rows_to_samples(const T& longMat) {
     return 0.5*(1 + sqrt(1 + 8*(longMat.rows())));
 }
 
-// These are inlined partially to avoid conflicting with the cuda
-// versions which have the same prototype
+#ifdef __NVCC__
+__host__ __device__
+#endif
 inline long calc_row_idx(const long long k, const long n) {
-	return n - 2 - floor(sqrt((double)(-8*k + 4*n*(n-1)-7))/2 - 0.5);
+#ifndef __CUDA_ARCH__
+	return n - 2 - floor(sqrt(static_cast<double>(-8*k + 4*n*(n-1)-7))/2 - 0.5);
+#else
+	// __ll2float_rn() casts long long to float, rounding to nearest
+	return n - 2 - floor(__dsqrt_rn(__ll2double_rz(-8*k + 4*n*(n-1)-7))/2 - 0.5);
+#endif
 }
 
+#ifdef __NVCC__
+__host__ __device__
+#endif
 inline long calc_col_idx(const long long k, const long i, const long n) {
 	return k + i + 1 - n*(n-1)/2 + (n-i)*((n-i)-1)/2;
 }
 
+#ifdef __NVCC__
+__host__ __device__
+#endif
 inline long long square_to_condensed(long i, long j, long n) {
     assert(j > i);
 	return (n*i - ((i*(i+1)) >> 1) + j - 1 - i);
 }
 
-NumpyMatrix long_to_square(const Eigen::VectorXf& rrDists, 
+NumpyMatrix long_to_square(const Eigen::VectorXf& rrDists,
                             const Eigen::VectorXf& qrDists,
                             const Eigen::VectorXf& qqDists,
                             unsigned int num_threads = 1);
 
-Eigen::VectorXf square_to_long(const NumpyMatrix& squareDists, 
+Eigen::VectorXf square_to_long(const NumpyMatrix& squareDists,
                                const unsigned int num_threads);
 
 sparse_coo sparsify_dists(const NumpyMatrix& denseDists,

--- a/src/dist/matrix_idx.hpp
+++ b/src/dist/matrix_idx.hpp
@@ -1,0 +1,43 @@
+/*
+ *
+ * matrix_idx.hpp
+ * long/square index conversion
+ *
+ */
+#pragma once
+
+#include <cstddef> // size_t
+#include <cmath> // floor/sqrt
+#include <cassert> // assert
+
+template<class T>
+inline size_t rows_to_samples(const T& longMat) {
+    return 0.5*(1 + sqrt(1 + 8*(longMat.rows())));
+}
+
+#ifdef __NVCC__
+__host__ __device__
+#endif
+inline long calc_row_idx(const long long k, const long n) {
+#ifndef __CUDA_ARCH__
+	return n - 2 - std::floor(std::sqrt(static_cast<double>(-8*k + 4*n*(n-1)-7))/2 - 0.5);
+#else
+	// __ll2float_rn() casts long long to float, rounding to nearest
+	return n - 2 - floor(__dsqrt_rn(__ll2double_rz(-8*k + 4*n*(n-1)-7))/2 - 0.5);
+#endif
+}
+
+#ifdef __NVCC__
+__host__ __device__
+#endif
+inline long calc_col_idx(const long long k, const long i, const long n) {
+	return k + i + 1 - n*(n-1)/2 + (n-i)*((n-i)-1)/2;
+}
+
+#ifdef __NVCC__
+__host__ __device__
+#endif
+inline long long square_to_condensed(long i, long j, long n) {
+    assert(j > i);
+	return (n*i - ((i*(i+1)) >> 1) + j - 1 - i);
+}

--- a/src/gpu/dist.cu
+++ b/src/gpu/dist.cu
@@ -21,7 +21,7 @@
 
 // internal headers
 #include "sketch/bitfuncs.hpp"
-#include "dist/matrix.hpp"
+#include "dist/matrix_idx.hpp"
 #include "gpu.hpp"
 #include "cuda.cuh"
 
@@ -120,24 +120,6 @@ void simple_linear_regression(float * core_dist,
 	} else {
 		*accessory_dist = 0;
 	}
-}
-
-// Functions to convert index position to/from squareform to condensed form
-__device__
-long calc_row_idx(const long long k, const long n) {
-	// __ll2float_rn() casts long long to float, rounding to nearest
-	return n - 2 - floor(__dsqrt_rn(__ll2double_rz(-8*k + 4*n*(n-1)-7))/2 - 0.5);
-}
-
-__device__
-long calc_col_idx(const long long k, const long i, const long n) {
-	return k + i + 1 - n*(n-1)/2 + (n-i)*((n-i)-1)/2;
-}
-
-__device__
-long long square_to_condensed(long i, long j, long n) {
-    assert(j > i);
-	return (n*i - ((i*(i+1)) >> 1) + j - 1 - i);
 }
 
 /******************

--- a/src/gpu/dist.cu
+++ b/src/gpu/dist.cu
@@ -23,6 +23,7 @@
 #include "sketch/bitfuncs.hpp"
 #include "gpu.hpp"
 #include "cuda.cuh"
+#include "matrix.hpp"
 
 /******************
 *			      *

--- a/src/gpu/dist.cu
+++ b/src/gpu/dist.cu
@@ -21,9 +21,9 @@
 
 // internal headers
 #include "sketch/bitfuncs.hpp"
+#include "dist/matrix.hpp"
 #include "gpu.hpp"
 #include "cuda.cuh"
-#include "matrix.hpp"
 
 /******************
 *			      *

--- a/src/gpu/gpu_api.cpp
+++ b/src/gpu/gpu_api.cpp
@@ -272,7 +272,7 @@ std::vector<uint64_t> flatten_by_bins(
 	std::vector<uint64_t> flat_ref(strides.sample_stride * num_sketches);
 	#pragma omp parallel for simd schedule(static) num_threads(cpu_threads)
 	for (int sample_idx = start_sample_idx; sample_idx < end_sample_idx; sample_idx++) {
-		auto flat_ref_it = flat_ref.begin() + sample_idx * strides.sample_stride;
+		auto flat_ref_it = flat_ref.begin() + (sample_idx - start_sample_idx) * strides.sample_stride;
 		for (auto kmer_it = kmer_lengths.cbegin(); kmer_it != kmer_lengths.cend(); kmer_it++) {
 			std::copy(sketches[sample_idx].get_sketch(*kmer_it).cbegin(),
 					  sketches[sample_idx].get_sketch(*kmer_it).cend(),


### PR DESCRIPTION
Trying to call inline __device__ functions (which are empty) from host code in gpu_api.cpp when `longtosquare` is called, causing a segfault. Also better this way, as avoids defining these twice