### PR TITLE
Use memcpy_async with CUDA 11

### DIFF
--- a/pp_sketch/__init__.py
+++ b/pp_sketch/__init__.py
@@ -3,4 +3,4 @@
 
 '''PopPUNK sketching functions'''
 
-__version__ = '1.6.5'
+__version__ = '1.7.0'

--- a/src/gpu/dist.cu
+++ b/src/gpu/dist.cu
@@ -19,6 +19,7 @@
 #include <unistd.h>
 #include <vector>
 
+// memcpy_async
 #if __CUDACC_VER_MAJOR__ >= 11
 #include <cuda/barrier>
 #include <cooperative_groups.h>

--- a/src/gpu/dist.cu
+++ b/src/gpu/dist.cu
@@ -193,7 +193,7 @@ __global__ void calculate_dists(
     auto block = cooperative_groups::this_thread_block();
     __shared__ cuda::barrier<cuda::thread_scope::thread_scope_block> barrier;
     if (block.thread_rank() == 0) {
-        init(&barrier, block.size()); // Friend function initializes barrier
+      init(&barrier, block.size()); // Friend function initializes barrier
     }
     block.sync();
 #endif
@@ -273,9 +273,9 @@ __global__ void calculate_dists(
 }
 
 /***************
- *			   *
+ *			       *
  *	Host code  *
- *			   *
+ *			       *
  ***************/
 
 // Sets up data structures and loads them onto the device

--- a/src/gpu/dist.cu
+++ b/src/gpu/dist.cu
@@ -187,17 +187,17 @@ __global__ void calculate_dists(
     const uint64_t *query_ptr;
     extern __shared__ uint64_t query_shared[];
     int query_bin_strides;
-    if (use_shared) {
-      size_t sketch_bins = query_strides.bbits * query_strides.sketchsize64;
-      size_t sketch_stride = query_strides.bin_stride;
 #if __CUDACC_VER_MAJOR__ >= 11
       cuda::barrier<cuda::thread_scope_block> barrier(10);
 #endif
+    if (use_shared) {
+      size_t sketch_bins = query_strides.bbits * query_strides.sketchsize64;
+      size_t sketch_stride = query_strides.bin_stride;
       if (threadIdx.x < warp_size) {
         for (int lidx = threadIdx.x; lidx < sketch_bins; lidx += warp_size) {
 #if __CUDACC_VER_MAJOR__ >= 11
-          cuda::memcpy_async(query_shared[lidx],
-                             query_start[lidx * sketch_stride],
+          cuda::memcpy_async(query_shared + lidx,
+                             query_start + (lidx * sketch_stride),
                              sizeof(uint64_t),
                              barrier);
 #else

--- a/src/gpu/dist.cu
+++ b/src/gpu/dist.cu
@@ -22,6 +22,7 @@
 #if __CUDACC_VER_MAJOR__ >= 11
 #include <cuda/barrier>
 #include <cooperative_groups.h>
+#pragma diag_suppress static_var_with_dynamic_init
 #endif
 
 // internal headers

--- a/src/gpu/dist.cu
+++ b/src/gpu/dist.cu
@@ -21,6 +21,7 @@
 
 #if __CUDACC_VER_MAJOR__ >= 11
 #include <cuda/pipeline>
+#include <cuda_pipeline.h>
 #endif
 
 // internal headers
@@ -191,12 +192,12 @@ __global__ void calculate_dists(
       size_t sketch_bins = query_strides.bbits * query_strides.sketchsize64;
       size_t sketch_stride = query_strides.bin_stride;
 #if __CUDACC_VER_MAJOR__ >= 11
-      pipeline pipe;
+      cuda::pipeline pipe;
 #endif
       if (threadIdx.x < warp_size) {
         for (int lidx = threadIdx.x; lidx < sketch_bins; lidx += warp_size) {
 #if __CUDACC_VER_MAJOR__ >= 11
-          memcpy_async(query_shared[lidx],
+          cuda::memcpy_async(query_shared[lidx],
                        query_start[lidx * sketch_stride], pipe);
 #else
           query_shared[lidx] = query_start[lidx * sketch_stride];

--- a/src/gpu/gpu_api.cpp
+++ b/src/gpu/gpu_api.cpp
@@ -91,7 +91,7 @@ std::vector<Reference> create_sketches_cuda(const std::string &db_name,
 
   if (resketch)
   {
-    Database sketch_db(db_name + ".h5", false);
+    Database sketch_db = new_db(db_name + ".h5", false);
     sketches.resize(names.size());
 
     initialise_device(device_id);


### PR DESCRIPTION
Replaces sync copy to shared with async copy available in CUDA 11. Both when loading query into shared (dist kernel), and reads into shared (sketch kernel).

Also fixes issue with mismatching CPU/GPU dists. To see this before:
```
poppunk_sketch --sketch --rfile 1000.ncbi_ncov.list --ref-db gpu_test_sketch --no-random
poppunk_sketch --query --ref-db gpu_test_sketch --query-db gpu_test_sketch --print --use-gpu --gpu-id 0 > gpu.out
poppunk_sketch --query --ref-db gpu_test_sketch --query-db gpu_test_sketch --print > cpu.out
```

If you load this into R you see the first 32 dists match, but the next set have an offset 
```
plot(cpu$Core[1:32], gpu$Core[1:32])
plot(cpu$Core[33:64], gpu$Core[33:64])
```