### PR TITLE
Add CPU progress bars and handle interrupts

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,17 +16,19 @@ file(WRITE src/version.h "\#define SKETCH_VERSION \"${sketch_hash}\"\n")
 set(TARGET_NAME pp_sketchlib)
 add_compile_definitions(PYTHON_EXT)
 
-# Add -O0 to remove optimizations when using gcc
+# gcc: Add openmp
+# gcc: Add -O0 to remove optimizations when using debug
 IF(CMAKE_COMPILER_IS_GNUCC)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fopenmp")
     set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -O0")
     set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -O0")
 ENDIF(CMAKE_COMPILER_IS_GNUCC)
 
 if(UNIX AND NOT APPLE)
     if(CMAKE_CXX_COMPILER STREQUAL "icpc")
-        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fopenmp -fast -xCASCADELAKE -DMKL_ILP64 -m64 -static-intel")
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fast -xCASCADELAKE -DMKL_ILP64 -m64 -static-intel")
     else()
-        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fopenmp -D__STDC_LIMIT_MACROS -D__STDC_CONSTANT_MACROS")
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D__STDC_LIMIT_MACROS -D__STDC_CONSTANT_MACROS")
         set(CMAKE_LD_FLAGS "${CMAKE_LDFLAGS} -Wl,--as-needed")
     endif()
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,8 @@ if(UNIX AND NOT APPLE)
         set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D__STDC_LIMIT_MACROS -D__STDC_CONSTANT_MACROS")
         set(CMAKE_LD_FLAGS "${CMAKE_LDFLAGS} -Wl,--as-needed")
     endif()
+    set_target_properties("${TARGET_NAME}" PROPERTIES
+                          INTERPROCEDURAL_OPTIMIZATION ON)
 endif()
 
 # Set paths for non standard lib/ and include/ locations
@@ -106,7 +108,6 @@ target_sources("${TARGET_NAME}" PRIVATE src/sketchlib_bindings.cpp
                                     src/random/random_match.cpp)
 set_target_properties("${TARGET_NAME}" PROPERTIES
     CXX_VISIBILITY_PRESET "hidden"
-    INTERPROCEDURAL_OPTIMIZATION TRUE
     PREFIX "${PYTHON_MODULE_PREFIX}"
     SUFFIX "${PYTHON_MODULE_EXTENSION}"
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,7 +77,7 @@ if(CMAKE_CUDA_COMPILER)
 
     add_compile_definitions(GPU_AVAILABLE)
     add_library("${TARGET_NAME}_CUDA" OBJECT src/gpu/dist.cu src/gpu/sketch.cu)
-    target_include_directories("${TARGET_NAME}_CUDA" PRIVATE "${EIGEN3_INCLUDE_DIR}")
+    target_include_directories("${TARGET_NAME}_CUDA" PRIVATE "${EIGEN3_INCLUDE_DIR}" "${pybind11_INCLUDE_DIRS}")
     set_property(TARGET "${TARGET_NAME}_CUDA"
                  PROPERTY POSITION_INDEPENDENT_CODE ON
                  CUDA_SEPARABLE_COMPILATION ON

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,8 +31,6 @@ if(UNIX AND NOT APPLE)
         set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D__STDC_LIMIT_MACROS -D__STDC_CONSTANT_MACROS")
         set(CMAKE_LD_FLAGS "${CMAKE_LDFLAGS} -Wl,--as-needed")
     endif()
-    set_target_properties("${TARGET_NAME}" PROPERTIES
-                          INTERPROCEDURAL_OPTIMIZATION ON)
 endif()
 
 # Set paths for non standard lib/ and include/ locations
@@ -111,6 +109,10 @@ set_target_properties("${TARGET_NAME}" PROPERTIES
     PREFIX "${PYTHON_MODULE_PREFIX}"
     SUFFIX "${PYTHON_MODULE_EXTENSION}"
 )
+if(UNIX AND (NOT APPLE OR NOT CMAKE_COMPILER_IS_GNUCC))
+    set_target_properties("${TARGET_NAME}" PROPERTIES
+                          INTERPROCEDURAL_OPTIMIZATION ON)
+endif()
 
 # Link libraries
 if(CMAKE_CUDA_COMPILER)

--- a/pp_sketch/__init__.py
+++ b/pp_sketch/__init__.py
@@ -3,4 +3,4 @@
 
 '''PopPUNK sketching functions'''
 
-__version__ = '1.7.1'
+__version__ = '1.7.2'

--- a/src/api.cpp
+++ b/src/api.cpp
@@ -86,7 +86,7 @@ std::vector<Reference> create_sketches(
           SeqBuf seq_in(files[i], kmer_lengths.back());
           sketches[i] = Reference(names[i], seq_in, kmer_seeds, sketchsize64,
                                   codon_phased, use_rc, min_count, exact);
-        } catch (const std::runtime_error& e) {
+        } catch (const std::runtime_error &e) {
 #pragma omp critical
           {
             errors.push_back(e);
@@ -95,19 +95,22 @@ std::vector<Reference> create_sketches(
         }
       }
 
-#pragma omp critical
-      {
-        sketch_progress.tick(1);
+      if (omp_get_thread_num() == 0) {
+        sketch_progress.tick(num_threads);
       }
     }
     sketch_progress.finalise();
 
-    // Handle Ctrl-C from python
+    // Handle errors including Ctrl-C from python
     if (interrupt) {
-      for (auto i = errors.cbegin(); i != error.cend(); ++i) {
+      for (auto i = errors.cbegin(); i != errors.cend(); ++i) {
         std::cout << i->what() << std::endl;
       }
-      throw py::error_already_set();
+      if (errors.size()) {
+        throw std::runtime_error("Errors during sketching");
+      } else {
+        throw py::error_already_set();
+      }
     }
 
     // Save sketches and check for densified sketches
@@ -165,6 +168,7 @@ NumpyMatrix query_db(std::vector<Reference> &ref_sketches,
   // These could be the same but out of order, which could be dealt with
   // using a sort, except the return order of the distances wouldn't be as
   // expected. self iff ref_names == query_names as input
+  bool interrupt = false;
   if (ref_sketches == query_sketches) {
     // calculate dists
     size_t dist_rows = static_cast<size_t>(0.5 * (ref_sketches.size()) *
@@ -174,23 +178,32 @@ NumpyMatrix query_db(std::vector<Reference> &ref_sketches,
     arma::mat kmer_mat = kmer2mat<std::vector<size_t>>(kmer_lengths);
 
     // Iterate upper triangle
+    ProgressMeter dist_progress(dist_rows, true);
 #pragma omp parallel for simd schedule(guided, 1) num_threads(num_threads)
     for (size_t i = 0; i < ref_sketches.size(); i++) {
-      for (size_t j = i + 1; j < ref_sketches.size(); j++) {
-        size_t pos = square_to_condensed(i, j, ref_sketches.size());
-        if (jaccard) {
-          for (unsigned int kmer_idx = 0; kmer_idx < kmer_lengths.size();
-               kmer_idx++) {
-            distMat(pos, kmer_idx) = ref_sketches[i].jaccard_dist(
-                ref_sketches[j], kmer_lengths[kmer_idx], random_chance);
+      if (interrupt || PyErr_CheckSignals() != 0) {
+        interrupt = true;
+      } else {
+        for (size_t j = i + 1; j < ref_sketches.size(); j++) {
+          size_t pos = square_to_condensed(i, j, ref_sketches.size());
+          if (jaccard) {
+            for (unsigned int kmer_idx = 0; kmer_idx < kmer_lengths.size();
+                kmer_idx++) {
+              distMat(pos, kmer_idx) = ref_sketches[i].jaccard_dist(
+                  ref_sketches[j], kmer_lengths[kmer_idx], random_chance);
+            }
+          } else {
+            std::tie(distMat(pos, 0), distMat(pos, 1)) =
+                ref_sketches[i].core_acc_dist<RandomMC>(ref_sketches[j], kmer_mat,
+                                                        random_chance);
           }
-        } else {
-          std::tie(distMat(pos, 0), distMat(pos, 1)) =
-              ref_sketches[i].core_acc_dist<RandomMC>(ref_sketches[j], kmer_mat,
-                                                      random_chance);
+        }
+        if (omp_get_thread_num() == 0) {
+          dist_progress.tick(ref_sketches.size() / 2);
         }
       }
     }
+    dist_progress.finalise();
   } else {
     // If ref != query, make a thread queue, with each element one ref
     // calculate dists
@@ -201,6 +214,7 @@ NumpyMatrix query_db(std::vector<Reference> &ref_sketches,
     arma::mat kmer_mat = kmer2mat<std::vector<size_t>>(kmer_lengths);
     std::vector<size_t> query_lengths(query_sketches.size());
     std::vector<uint16_t> query_random_idxs(query_sketches.size());
+
 #pragma omp parallel for simd schedule(static) num_threads(num_threads)
     for (unsigned int q_idx = 0; q_idx < query_sketches.size(); q_idx++) {
       query_lengths[q_idx] = query_sketches[q_idx].seq_length();
@@ -208,29 +222,43 @@ NumpyMatrix query_db(std::vector<Reference> &ref_sketches,
           random_chance.closest_cluster(query_sketches[q_idx]);
     }
 
+    ProgressMeter dist_progress(dist_rows, true);
 #pragma omp parallel for collapse(2) schedule(static) num_threads(num_threads)
     for (unsigned int q_idx = 0; q_idx < query_sketches.size(); q_idx++) {
       for (unsigned int r_idx = 0; r_idx < ref_sketches.size(); r_idx++) {
-        const long dist_row = q_idx * ref_sketches.size() + r_idx;
-        if (jaccard) {
-          for (unsigned int kmer_idx = 0; kmer_idx < kmer_lengths.size();
-               kmer_idx++) {
-            double jaccard_random = random_chance.random_match(
-                ref_sketches[r_idx], query_random_idxs[q_idx],
-                query_lengths[q_idx], kmer_lengths[kmer_idx]);
-            distMat(dist_row, kmer_idx) = query_sketches[q_idx].jaccard_dist(
-                ref_sketches[r_idx], kmer_lengths[kmer_idx], jaccard_random);
-          }
+        if (interrupt || PyErr_CheckSignals() != 0) {
+          interrupt = true;
         } else {
-          std::vector<double> jaccard_random = random_chance.random_matches(
-              ref_sketches[r_idx], query_random_idxs[q_idx],
-              query_lengths[q_idx], kmer_lengths);
-          std::tie(distMat(dist_row, 0), distMat(dist_row, 1)) =
-              query_sketches[q_idx].core_acc_dist<std::vector<double>>(
-                  ref_sketches[r_idx], kmer_mat, jaccard_random);
+          const long dist_row = q_idx * ref_sketches.size() + r_idx;
+          if (jaccard) {
+            for (unsigned int kmer_idx = 0; kmer_idx < kmer_lengths.size();
+                kmer_idx++) {
+              double jaccard_random = random_chance.random_match(
+                  ref_sketches[r_idx], query_random_idxs[q_idx],
+                  query_lengths[q_idx], kmer_lengths[kmer_idx]);
+              distMat(dist_row, kmer_idx) = query_sketches[q_idx].jaccard_dist(
+                  ref_sketches[r_idx], kmer_lengths[kmer_idx], jaccard_random);
+            }
+          } else {
+            std::vector<double> jaccard_random = random_chance.random_matches(
+                ref_sketches[r_idx], query_random_idxs[q_idx],
+                query_lengths[q_idx], kmer_lengths);
+            std::tie(distMat(dist_row, 0), distMat(dist_row, 1)) =
+                query_sketches[q_idx].core_acc_dist<std::vector<double>>(
+                    ref_sketches[r_idx], kmer_mat, jaccard_random);
+          }
+          if (omp_get_thread_num() == 0) {
+            dist_progress.tick(num_threads);
+          }
         }
       }
     }
+    dist_progress.finalise();
+  }
+
+  // Handle Ctrl-C from python
+  if (interrupt) {
+    throw py::error_already_set();
   }
 
   return (distMat);

--- a/src/gpu/cuda.cuh
+++ b/src/gpu/cuda.cuh
@@ -40,7 +40,7 @@ struct progress_atomics {
   }
 
   void free() {
-    CUDA_CALL(cudaFree(blocks_complete));
+    CUDA_CALL(cudaFree((void *)blocks_complete));
     CUDA_CALL(cudaFree(kill_kernel));
   }
 };

--- a/src/gpu/cuda.cuh
+++ b/src/gpu/cuda.cuh
@@ -52,7 +52,9 @@ __device__ inline void update_progress(long long dist_idx, long long dist_n,
   // Progress indicator
   // The >> progressBitshift is a divide by 1024 - update roughly every 0.1%
   if (dist_idx % (dist_n >> progressBitshift) == 0) {
-    assert(progress.kill_kernel);
+    if (*(progress.kill_kernel) == true) {
+      __trap();
+    }
     atomicAdd((int *)progress.blocks_complete, 1);
     __threadfence_system();
   }

--- a/src/gpu/cuda.cuh
+++ b/src/gpu/cuda.cuh
@@ -7,6 +7,24 @@
 #include <cuda_runtime.h>
 #include <device_launch_parameters.h>
 
+// A bit lazy... should be a class and just use the destructor
+struct progress_atomics {
+  volatile int *blocks_complete;
+  bool *kill_kernel;
+
+  init() {
+    CUDA_CALL(cudaMallocManaged(&blocks_complete, sizeof(int)));
+    CUDA_CALL(cudaMallocManaged(&kill_kernel, sizeof(bool)));
+    *blocks_complete = 0;
+    *kill_kernel = false;
+  }
+
+  free() {
+    CUDA_CALL(cudaFree(blocks_complete));
+    CUDA_CALL(cudaFree(kill_kernel));
+  }
+};
+
 const int progressBitshift = 10; // Update every 2^10 = 1024 dists
 
 static void HandleCUDAError(const char *file, int line,
@@ -30,12 +48,12 @@ static void HandleCUDAError(const char *file, int line,
 // Use atomic add to update a counter, so progress works regardless of
 // dispatch order
 __device__ inline void update_progress(long long dist_idx, long long dist_n,
-                                       volatile int *blocks_complete) {
+                                       progress_atomics progress) {
   // Progress indicator
   // The >> progressBitshift is a divide by 1024 - update roughly every 0.1%
   if (dist_idx % (dist_n >> progressBitshift) == 0) {
-    assert(blocks_complete >= 0);
-    atomicAdd((int *)blocks_complete, 1);
+    assert(progress.kill_kernel);
+    atomicAdd((int *)progress.blocks_complete, 1);
     __threadfence_system();
   }
 }

--- a/src/gpu/cuda.cuh
+++ b/src/gpu/cuda.cuh
@@ -34,6 +34,7 @@ __device__ inline void update_progress(long long dist_idx, long long dist_n,
   // Progress indicator
   // The >> progressBitshift is a divide by 1024 - update roughly every 0.1%
   if (dist_idx % (dist_n >> progressBitshift) == 0) {
+    assert(blocks_complete >= 0);
     atomicAdd((int *)blocks_complete, 1);
     __threadfence_system();
   }

--- a/src/gpu/dist.cu
+++ b/src/gpu/dist.cu
@@ -405,6 +405,8 @@ void reportDistProgress(volatile int *blocks_complete, long long dist_rows) {
   if (dist_rows > progress_blocks) {
     while (now_completed < progress_blocks - 1) {
       if (PyErr_CheckSignals() != 0) {
+        // I'm ignoring a race condition here
+        *blocks_complete = -1;
         throw py::error_already_set();
       }
       if (*blocks_complete > now_completed) {

--- a/src/gpu/dist.cu
+++ b/src/gpu/dist.cu
@@ -19,6 +19,9 @@
 #include <unistd.h>
 #include <vector>
 
+#include <pybind11/pybind11.h>
+namespace py = pybind11;
+
 // memcpy_async
 #if __CUDACC_VER_MAJOR__ >= 11
 #include <cuda/barrier>
@@ -401,6 +404,9 @@ void reportDistProgress(volatile int *blocks_complete, long long dist_rows) {
   float kern_progress = 0;
   if (dist_rows > progress_blocks) {
     while (now_completed < progress_blocks - 1) {
+      if (PyErr_CheckSignals() != 0) {
+        throw py::error_already_set();
+      }
       if (*blocks_complete > now_completed) {
         now_completed = *blocks_complete;
         kern_progress = now_completed / (float)progress_blocks;

--- a/src/gpu/dist.cu
+++ b/src/gpu/dist.cu
@@ -405,11 +405,11 @@ void reportDistProgress(progress_atomics progress, long long dist_rows) {
   if (dist_rows > progress_blocks) {
     while (now_completed < progress_blocks - 1) {
       if (PyErr_CheckSignals() != 0) {
-        *progress.kill_kernel = true;
+        *(progress.kill_kernel) = true;
         throw py::error_already_set();
       }
-      if (*progress.blocks_complete > now_completed) {
-        now_completed = *progress.blocks_complete;
+      if (*(progress.blocks_complete) > now_completed) {
+        now_completed = *(progress.blocks_complete);
         kern_progress = now_completed / (float)progress_blocks;
         fprintf(stderr, "%cProgress (GPU): %.1lf%%", 13, kern_progress * 100);
       } else {

--- a/src/gpu/dist.cu
+++ b/src/gpu/dist.cu
@@ -143,7 +143,7 @@ __global__ void calculate_dists(
     const float *random_table, const uint16_t *ref_idx_lookup,
     const uint16_t *query_idx_lookup, const SketchStrides ref_strides,
     const SketchStrides query_strides, const RandomStrides random_strides,
-    volatile int *blocks_complete, const bool use_shared) {
+    progress_atomics progress, const bool use_shared) {
   // Calculate indices for query, ref and results
   int ref_idx, query_idx, dist_idx;
   if (self) {
@@ -283,7 +283,7 @@ __global__ void calculate_dists(
     simple_linear_regression(dists + dist_idx, dists + dist_n + dist_idx, xsum,
                              ysum, xysum, xsquaresum, ysquaresum, kmer_used);
 
-    update_progress(dist_idx, dist_n, blocks_complete);
+    update_progress(dist_idx, dist_n, progress);
   }
 }
 
@@ -398,19 +398,18 @@ std::tuple<size_t, size_t> getBlockSize(const size_t ref_samples,
 
 // Writes a progress meter using the device int which keeps
 // track of completed jobs
-void reportDistProgress(volatile int *blocks_complete, long long dist_rows) {
+void reportDistProgress(progress_atomics progress, long long dist_rows) {
   long long progress_blocks = 1 << progressBitshift;
   int now_completed = 0;
   float kern_progress = 0;
   if (dist_rows > progress_blocks) {
     while (now_completed < progress_blocks - 1) {
       if (PyErr_CheckSignals() != 0) {
-        // I'm ignoring a race condition here
-        *blocks_complete = -1;
+        *progress.kill_kernel = true;
         throw py::error_already_set();
       }
-      if (*blocks_complete > now_completed) {
-        now_completed = *blocks_complete;
+      if (*progress.blocks_complete > now_completed) {
+        now_completed = *progress.blocks_complete;
         kern_progress = now_completed / (float)progress_blocks;
         fprintf(stderr, "%cProgress (GPU): %.1lf%%", 13, kern_progress * 100);
       } else {
@@ -454,9 +453,8 @@ std::vector<float> dispatchDists(std::vector<Reference> &ref_sketches,
   CUDA_CALL(cudaDeviceSetSharedMemConfig(cudaSharedMemBankSizeEightByte));
 
   // Progress meter
-  volatile int *blocks_complete;
-  CUDA_CALL(cudaMallocManaged(&blocks_complete, sizeof(int)));
-  *blocks_complete = 0;
+  progress_atomics progress;
+  progress.init();
 
   RandomStrides random_strides = std::get<0>(flat_random);
   long long dist_rows;
@@ -502,7 +500,7 @@ std::vector<float> dispatchDists(std::vector<Reference> &ref_sketches,
         device_arrays.kmers(), kmer_lengths.size(), device_arrays.dist_mat(),
         dist_rows, device_arrays.random_table(), device_arrays.ref_random(),
         device_arrays.ref_random(), ref_strides, ref_strides, random_strides,
-        blocks_complete, use_shared);
+        progress, use_shared);
   } else {
     std::tie(blockSize, blockCount) =
         getBlockSize(sketch_subsample.ref_size, sketch_subsample.query_size,
@@ -517,13 +515,14 @@ std::vector<float> dispatchDists(std::vector<Reference> &ref_sketches,
         device_arrays.kmers(), kmer_lengths.size(), device_arrays.dist_mat(),
         dist_rows, device_arrays.random_table(), device_arrays.ref_random(),
         device_arrays.query_random(), ref_strides, query_strides,
-        random_strides, blocks_complete, use_shared);
+        random_strides, progress, use_shared);
   }
 
   // Check for error in kernel launch
   CUDA_CALL(cudaGetLastError());
-  reportDistProgress(blocks_complete, dist_rows);
+  reportDistProgress(progress, dist_rows);
   fprintf(stderr, "%cProgress (GPU): 100.0%%\n", 13);
+  progress.free();
 
   // Copy results back to host
   CUDA_CALL(cudaDeviceSynchronize());

--- a/src/gpu/gpu.hpp
+++ b/src/gpu/gpu.hpp
@@ -6,9 +6,9 @@
  */
 #pragma once
 
-#include <vector>
-#include <cstdint>
 #include <cstddef>
+#include <cstdint>
+#include <vector>
 
 #include "reference.hpp"
 
@@ -26,8 +26,7 @@ static const int warp_size = 32;
 #error "Please provide a definition for MY_ALIGN macro for your host compiler!"
 #endif
 
-struct ALIGN(8) RandomStrides
-{
+struct ALIGN(8) RandomStrides {
   size_t kmer_stride;
   size_t cluster_inner_stride;
   size_t cluster_outer_stride;
@@ -37,8 +36,7 @@ typedef std::tuple<RandomStrides, std::vector<float>> FlatRandom;
 
 #ifdef GPU_AVAILABLE
 // Structure of flattened vectors
-struct ALIGN(16) SketchStrides
-{
+struct ALIGN(16) SketchStrides {
   size_t bin_stride;
   size_t kmer_stride;
   size_t sample_stride;
@@ -46,8 +44,7 @@ struct ALIGN(16) SketchStrides
   size_t bbits;
 };
 
-struct ALIGN(8) SketchSlice
-{
+struct ALIGN(8) SketchSlice {
   size_t ref_offset;
   size_t ref_size;
   size_t query_offset;
@@ -57,52 +54,42 @@ struct ALIGN(8) SketchSlice
 // defined in dist.cu
 std::tuple<size_t, size_t, size_t> initialise_device(const int device_id);
 
-std::vector<uint64_t> flatten_by_bins(
-    const std::vector<Reference> &sketches,
-    const std::vector<size_t> &kmer_lengths,
-    SketchStrides &strides,
-    const size_t start_sample_idx,
-    const size_t end_sample_idx,
-    const int cpu_threads = 1);
+std::vector<uint64_t> flatten_by_bins(const std::vector<Reference> &sketches,
+                                      const std::vector<size_t> &kmer_lengths,
+                                      SketchStrides &strides,
+                                      const size_t start_sample_idx,
+                                      const size_t end_sample_idx,
+                                      const int cpu_threads = 1);
 
-std::vector<uint64_t> flatten_by_samples(
-    const std::vector<Reference> &sketches,
-    const std::vector<size_t> &kmer_lengths,
-    SketchStrides &strides,
-    const size_t start_sample_idx,
-    const size_t end_sample_idx,
-    const int cpu_threads = 1);
+std::vector<uint64_t>
+flatten_by_samples(const std::vector<Reference> &sketches,
+                   const std::vector<size_t> &kmer_lengths,
+                   SketchStrides &strides, const size_t start_sample_idx,
+                   const size_t end_sample_idx, const int cpu_threads = 1);
 
-std::vector<float> dispatchDists(
-    std::vector<Reference> &ref_sketches,
-    std::vector<Reference> &query_sketches,
-    SketchStrides &ref_strides,
-    SketchStrides &query_strides,
-    const FlatRandom &flat_random,
-    const std::vector<uint16_t> &ref_random_idx,
-    const std::vector<uint16_t> &query_random_idx,
-    const SketchSlice &sketch_subsample,
-    const std::vector<size_t> &kmer_lengths,
-    const bool self,
-    const int cpu_threads,
-    const size_t shared_size);
+std::vector<float> dispatchDists(std::vector<Reference> &ref_sketches,
+                                 std::vector<Reference> &query_sketches,
+                                 SketchStrides &ref_strides,
+                                 SketchStrides &query_strides,
+                                 const FlatRandom &flat_random,
+                                 const std::vector<uint16_t> &ref_random_idx,
+                                 const std::vector<uint16_t> &query_random_idx,
+                                 const SketchSlice &sketch_subsample,
+                                 const std::vector<size_t> &kmer_lengths,
+                                 const bool self, const int cpu_threads,
+                                 const size_t shared_size);
 
 // Memory on device for each operation
-class DeviceMemory
-{
+class DeviceMemory {
 public:
-  DeviceMemory(SketchStrides &ref_strides,
-               SketchStrides &query_strides,
+  DeviceMemory(SketchStrides &ref_strides, SketchStrides &query_strides,
                std::vector<Reference> &ref_sketches,
                std::vector<Reference> &query_sketches,
-               const SketchSlice &sample_slice,
-               const FlatRandom &flat_random,
+               const SketchSlice &sample_slice, const FlatRandom &flat_random,
                const std::vector<uint16_t> &ref_random_idx,
                const std::vector<uint16_t> &query_random_idx,
-               const std::vector<size_t> &kmer_lengths,
-               long long dist_rows,
-               const bool self,
-               const int cpu_threads);
+               const std::vector<size_t> &kmer_lengths, long long dist_rows,
+               const bool self, const int cpu_threads);
 
   ~DeviceMemory();
 
@@ -131,8 +118,7 @@ private:
 };
 
 // defined in sketch.cu
-class GPUCountMin
-{
+class GPUCountMin {
 public:
   GPUCountMin();
   ~GPUCountMin();
@@ -156,8 +142,7 @@ private:
   const size_t _table_cells;
 };
 
-class DeviceReads
-{
+class DeviceReads {
 public:
   DeviceReads(const SeqBuf &seq_in, const size_t n_threads);
   ~DeviceReads();
@@ -180,12 +165,9 @@ private:
 
 void copyNtHashTablesToDevice();
 
-std::vector<uint64_t> get_signs(DeviceReads &reads,
-                                GPUCountMin &countmin,
-                                const int k,
-                                const bool use_rc,
+std::vector<uint64_t> get_signs(DeviceReads &reads, GPUCountMin &countmin,
+                                const int k, const bool use_rc,
                                 const uint16_t min_count,
-                                const uint64_t binsize,
-                                const uint64_t nbins);
+                                const uint64_t binsize, const uint64_t nbins);
 
 #endif

--- a/src/gpu/sketch.cu
+++ b/src/gpu/sketch.cu
@@ -8,6 +8,9 @@
 
 #include <stdint.h>
 
+#include <pybind11/pybind11.h>
+namespace py = pybind11;
+
 // memcpy_async
 #if __CUDACC_VER_MAJOR__ >= 11
 #include <cuda/barrier>
@@ -292,6 +295,9 @@ void reportSketchProgress(volatile int *blocks_complete, int k,
   float kern_progress = 0;
   if (n_reads > progress_blocks) {
     while (now_completed < progress_blocks - 1) {
+      if (PyErr_CheckSignals() != 0) {
+        throw py::error_already_set();
+      }
       if (*blocks_complete > now_completed) {
         now_completed = *blocks_complete;
         kern_progress = now_completed / (float)progress_blocks;

--- a/src/gpu/sketch.cu
+++ b/src/gpu/sketch.cu
@@ -296,11 +296,11 @@ void reportSketchProgress(progress_atomics progress, int k,
   if (n_reads > progress_blocks) {
     while (now_completed < progress_blocks - 1) {
       if (PyErr_CheckSignals() != 0) {
-        *progress.kill_kernel = true;
+        *(progress.kill_kernel) = true;
         throw py::error_already_set();
       }
-      if (*progress.blocks_complete > now_completed) {
-        now_completed = *progress.blocks_complete;
+      if (*(progress.blocks_complete) > now_completed) {
+        now_completed = *(progress.blocks_complete);
         kern_progress = now_completed / (float)progress_blocks;
         fprintf(stderr, "%ck = %d (%.1lf%%)", 13, k, kern_progress * 100);
       } else {

--- a/src/gpu/sketch.cu
+++ b/src/gpu/sketch.cu
@@ -223,7 +223,7 @@ __global__ void process_reads(char *read_seq, const size_t n_reads,
                               uint64_t *signs, const uint64_t binsize,
                               unsigned int *countmin_table, const bool use_rc,
                               const uint16_t min_count,
-                              volatile int *blocks_complete) {
+                              progress_atomics progress) {
   int read_index = blockIdx.x * blockDim.x + threadIdx.x;
   uint64_t fhVal, rhVal, hVal;
 
@@ -281,14 +281,14 @@ __global__ void process_reads(char *read_seq, const size_t n_reads,
     }
 
     // update progress meter
-    update_progress(read_index, n_reads, blocks_complete);
+    update_progress(read_index, n_reads, progress);
   }
   __syncwarp();
 }
 
 // Writes a progress meter using the device int which keeps
 // track of completed jobs
-void reportSketchProgress(volatile int *blocks_complete, int k,
+void reportSketchProgress(progress_atomics progress, int k,
                           long long n_reads) {
   long long progress_blocks = 1 << progressBitshift;
   int now_completed = 0;
@@ -296,12 +296,11 @@ void reportSketchProgress(volatile int *blocks_complete, int k,
   if (n_reads > progress_blocks) {
     while (now_completed < progress_blocks - 1) {
       if (PyErr_CheckSignals() != 0) {
-        // I'm ignoring a race condition here
-        *blocks_complete = -1;
+        *progress.kill_kernel = true;
         throw py::error_already_set();
       }
-      if (*blocks_complete > now_completed) {
-        now_completed = *blocks_complete;
+      if (*progress.blocks_complete > now_completed) {
+        now_completed = *progress.blocks_complete;
         kern_progress = now_completed / (float)progress_blocks;
         fprintf(stderr, "%ck = %d (%.1lf%%)", 13, k, kern_progress * 100);
       } else {
@@ -502,9 +501,8 @@ get_signs(DeviceReads &reads, // use seqbuf.as_square_array() to get this
           const uint16_t min_count, const uint64_t binsize,
           const uint64_t nbins) {
   // Progress meter
-  volatile int *blocks_complete;
-  CUDA_CALL(cudaMallocManaged(&blocks_complete, sizeof(int)));
-  *blocks_complete = 0;
+  progress_atomics progress;
+  progress.init();
 
   // Set countmin to zero (already on device)
   countmin.reset();
@@ -526,7 +524,7 @@ get_signs(DeviceReads &reads, // use seqbuf.as_square_array() to get this
                   reads.length() * blockSize * sizeof(char)>>>(
       reads.read_ptr(), reads.count(), reads.length(), reads.stride(), k,
       d_signs, binsize, countmin.get_table(), use_rc, min_count,
-      blocks_complete);
+      progress);
 
   CUDA_CALL(cudaGetLastError());
   reportSketchProgress(blocks_complete, k, reads.count());
@@ -538,6 +536,7 @@ get_signs(DeviceReads &reads, // use seqbuf.as_square_array() to get this
   CUDA_CALL(cudaFree(d_signs));
 
   fprintf(stderr, "%ck = %d (100%%)", 13, k);
+  progress.free();
 
   return (signs);
 }

--- a/src/gpu/sketch.cu
+++ b/src/gpu/sketch.cu
@@ -296,6 +296,8 @@ void reportSketchProgress(volatile int *blocks_complete, int k,
   if (n_reads > progress_blocks) {
     while (now_completed < progress_blocks - 1) {
       if (PyErr_CheckSignals() != 0) {
+        // I'm ignoring a race condition here
+        *blocks_complete = -1;
         throw py::error_already_set();
       }
       if (*blocks_complete > now_completed) {

--- a/src/gpu/sketch.cu
+++ b/src/gpu/sketch.cu
@@ -527,7 +527,7 @@ get_signs(DeviceReads &reads, // use seqbuf.as_square_array() to get this
       progress);
 
   CUDA_CALL(cudaGetLastError());
-  reportSketchProgress(blocks_complete, k, reads.count());
+  reportSketchProgress(progress, k, reads.count());
 
   // Copy signs back from device
   CUDA_CALL(cudaDeviceSynchronize());

--- a/src/sketch/progress.hpp
+++ b/src/sketch/progress.hpp
@@ -12,7 +12,7 @@ public:
     if (percent_) {
       double progress = count_ / static_cast<double>(total_);
       progress = progress > 1 ? 1 : progress;
-      fprintf(stderr, "%cProgress (CPU): %.1lf%%", 13, progress * 100, total_);
+      fprintf(stderr, "%cProgress (CPU): %.1lf%%", 13, progress * 100);
     } else {
       size_t progress = count_ <= total_ ? count_ : total_;
       fprintf(stderr, "%cProgress (CPU): %lu / %lu", 13, progress, total_);

--- a/src/sketch/progress.hpp
+++ b/src/sketch/progress.hpp
@@ -1,0 +1,19 @@
+#pragma once
+
+class ProgressMeter {
+public:
+  ProgressMeter(size_t total) : total_(total), count_(0) { tick(0); }
+
+  void tick(size_t blocks) {
+    count_ += blocks;
+    double progress = count_ / static_cast<double>(total_);
+    progress = progress > 1 ? 1 : progress;
+    fprintf(stderr, "%cProgress (CPU): %.1lf%%", 13, progress * 100);
+  }
+
+  void finalise() { fprintf(stderr, "%cProgress (CPU): 100.0%%\n", 13); }
+
+private:
+  size_t total_;
+  volatile size_t count_;
+};

--- a/src/sketch/progress.hpp
+++ b/src/sketch/progress.hpp
@@ -2,18 +2,33 @@
 
 class ProgressMeter {
 public:
-  ProgressMeter(size_t total) : total_(total), count_(0) { tick(0); }
+  ProgressMeter(size_t total, bool percent = false)
+      : total_(total), percent_(percent), count_(0) {
+    tick(0);
+  }
 
   void tick(size_t blocks) {
     count_ += blocks;
-    double progress = count_ / static_cast<double>(total_);
-    progress = progress > 1 ? 1 : progress;
-    fprintf(stderr, "%cProgress (CPU): %.1lf%%", 13, progress * 100);
+    if (percent_) {
+      double progress = count_ / static_cast<double>(total_);
+      progress = progress > 1 ? 1 : progress;
+      fprintf(stderr, "%cProgress (CPU): %.1lf%%", 13, progress * 100, total_);
+    } else {
+      size_t progress = count_ <= total_ ? count_ : total_;
+      fprintf(stderr, "%cProgress (CPU): %lu / %lu", 13, progress, total_);
+    }
   }
 
-  void finalise() { fprintf(stderr, "%cProgress (CPU): 100.0%%\n", 13); }
+  void finalise() {
+    if (percent_) {
+      fprintf(stderr, "%cProgress (CPU): 100.0%%\n", 13);
+    } else {
+      fprintf(stderr, "%cProgress (CPU): %lu / %lu\n", 13, total_, total_);
+    }
+  }
 
 private:
   size_t total_;
+  bool percent_;
   volatile size_t count_;
 };


### PR DESCRIPTION
This PR: 
- adds progress meters when sketching and calculating distances
- handles Ctrl-C interrupts for CPU sketching and distances
- handles Ctrl-C interrupts for GPU sketching and distances (causes the kernel to fail, so gives a CUDA error rather than a KeyboardInterrupt, but I think this is ok)
- properly deals exceptions in the openmp sketch block, which displays the 'no sequence' errors correctly

Closes #38 