### PR TITLE
Fix for multiblock GPU dists

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -37,7 +37,7 @@ steps:
 # pushd src && make && make install && popd
 - script: |
     source activate pp_env
-    export CUDA_HOME=/usr/local/cuda-12.6
+    export CUDA_HOME=/usr/local/cuda-12.8
     export PATH=${CUDA_HOME}/bin${PATH:+:${PATH}}
     export LD_LIBRARY_PATH=${CUDA_HOME}/lib64${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}
     export SKETCHLIB_INSTALL=azure
@@ -46,7 +46,7 @@ steps:
 
 - script: |
     source activate pp_env
-    export CUDA_HOME=/usr/local/cuda-12.6
+    export CUDA_HOME=/usr/local/cuda-12.8
     export PATH=${CUDA_HOME}/bin${PATH:+:${PATH}}
     export LD_LIBRARY_PATH=${CUDA_HOME}/lib64${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}
     cd test && python run_test.py

--- a/pp_sketch/__init__.py
+++ b/pp_sketch/__init__.py
@@ -3,4 +3,4 @@
 
 '''PopPUNK sketching functions'''
 
-__version__ = '2.1.4'
+__version__ = '2.1.5'

--- a/src/gpu/gpu_api.cpp
+++ b/src/gpu/gpu_api.cpp
@@ -201,8 +201,8 @@ void longToSquareBlock(NumpyMatrix &coreSquare, NumpyMatrix &accessorySquare,
                                  dummy_query_query, num_threads);
   } else {
     square_form = Eigen::Map<NumpyMatrix, 0, Eigen::InnerStride<2>>(
-        blockMat.data(), sketch_subsample.ref_size,
-        sketch_subsample.query_size);
+        blockMat.data(), sketch_subsample.query_size,
+        sketch_subsample.ref_size);
   }
   // Only update the upper triangle
   coreSquare.block(sketch_subsample.query_offset, sketch_subsample.ref_offset,
@@ -214,8 +214,8 @@ void longToSquareBlock(NumpyMatrix &coreSquare, NumpyMatrix &accessorySquare,
                                  dummy_query_query, num_threads);
   } else {
     square_form = Eigen::Map<NumpyMatrix, 0, Eigen::InnerStride<2>>(
-        blockMat.data() + 1, sketch_subsample.ref_size,
-        sketch_subsample.query_size);
+        blockMat.data() + 1, sketch_subsample.query_size,
+        sketch_subsample.ref_size);
   }
   accessorySquare.block(
       sketch_subsample.query_offset, sketch_subsample.ref_offset,


### PR DESCRIPTION
Rectangular parts were being transposed to the wrong size, overwriting some elements and leaving others as uninitialised

For future, to test this set an odd sample size and run with chunks = 3 in gpu_api.cpp

`python sketchlib-runner.py query dist listeria.h5 --gpu 1`

Other notes from build:
- Used gcc-11 from homebrew, but no longer necessary with newer cuda
- Need to be added to `vglusers` group to run CUDA now
- hdf5 LD_LIBRARY_PATH needs to be set to conda dir
- `export SKETCHLIB_INSTALL=local`, and set path and ld_library_path to include nvcc too