### PR TITLE
Fix segfault with bad distance comparisons

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,7 +60,7 @@ execute_process(COMMAND pybind11-config --cmakedir OUTPUT_STRIP_TRAILING_WHITESP
 find_package(pybind11 2.6 CONFIG REQUIRED)
 
 # Linear algebra packages
-find_package(Eigen3 3.3 REQUIRED NO_MODULE)
+find_package(Eigen3 REQUIRED NO_MODULE)
 find_package(BLAS)
 if(BLAS_FOUND)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DEIGEN_USE_BLAS")

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -27,7 +27,7 @@ steps:
     wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/cuda-keyring_1.1-1_all.deb
     sudo dpkg -i cuda-keyring_1.1-1_all.deb
     sudo apt-get update
-    sudo apt-get -y install cuda-toolkit
+    sudo apt-get -y install cuda-toolkit=12.8
   displayName: Install nvcc
 
 - bash: conda env create --file environment.yml

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -27,7 +27,7 @@ steps:
     wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/cuda-keyring_1.1-1_all.deb
     sudo dpkg -i cuda-keyring_1.1-1_all.deb
     sudo apt-get update
-    sudo apt-get -y install cuda-toolkit=12.8
+    sudo apt-get -y install cuda-toolkit=12
   displayName: Install nvcc
 
 - bash: conda env create --file environment.yml

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,5 +1,7 @@
 # This just checks the package can be installed using CUDA, no testing
 
+# 2026-06-08 This test no longer works as it's not possible to install CUDA in the space available on the runner
+
 trigger:
 - master
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -27,7 +27,7 @@ steps:
     wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/cuda-keyring_1.1-1_all.deb
     sudo dpkg -i cuda-keyring_1.1-1_all.deb
     sudo apt-get update
-    sudo apt-get -y install cuda-toolkit=12
+    sudo apt-get -y install cuda-toolkit
   displayName: Install nvcc
 
 - bash: conda env create --file environment.yml
@@ -37,7 +37,7 @@ steps:
 # pushd src && make && make install && popd
 - script: |
     source activate pp_env
-    export CUDA_HOME=/usr/local/cuda-12.8
+    export CUDA_HOME=/usr/local/cuda-13.3
     export PATH=${CUDA_HOME}/bin${PATH:+:${PATH}}
     export LD_LIBRARY_PATH=${CUDA_HOME}/lib64${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}
     export SKETCHLIB_INSTALL=azure
@@ -46,7 +46,7 @@ steps:
 
 - script: |
     source activate pp_env
-    export CUDA_HOME=/usr/local/cuda-12.8
+    export CUDA_HOME=/usr/local/cuda-13.3
     export PATH=${CUDA_HOME}/bin${PATH:+:${PATH}}
     export LD_LIBRARY_PATH=${CUDA_HOME}/lib64${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}
     cd test && python run_test.py

--- a/environment.yml
+++ b/environment.yml
@@ -22,4 +22,4 @@ dependencies:
   - openblas
   - libgfortran-ng
   - nvcc_linux-64
-  - cudatoolkit # This is pinned due to version install on azure, see azure-pipelines.yml
+  - cudatoolkit=13.3 # This is pinned due to version install on azure, see azure-pipelines.yml

--- a/environment.yml
+++ b/environment.yml
@@ -22,4 +22,4 @@ dependencies:
   - openblas
   - libgfortran-ng
   - nvcc_linux-64
-  - cuda-toolkit=13.3 # This is pinned due to version install on azure, see azure-pipelines.yml
+  #- cuda-toolkit=13.3 # This is pinned due to version install on azure, see azure-pipelines.yml

--- a/environment.yml
+++ b/environment.yml
@@ -22,4 +22,4 @@ dependencies:
   - openblas
   - libgfortran-ng
   - nvcc_linux-64
-  - cudatoolkit=13.3 # This is pinned due to version install on azure, see azure-pipelines.yml
+  - cuda-toolkit=13.3 # This is pinned due to version install on azure, see azure-pipelines.yml

--- a/pp_sketch/__init__.py
+++ b/pp_sketch/__init__.py
@@ -3,4 +3,4 @@
 
 '''PopPUNK sketching functions'''
 
-__version__ = '2.1.5'
+__version__ = '2.2.0'

--- a/src/Makefile
+++ b/src/Makefile
@@ -29,13 +29,8 @@ CPPFLAGS+=-I"." -I$(LIBLOC)/include -I$(LIBLOC)/include/eigen3
 LDFLAGS+= -L$(LIBLOC)/lib
 CUDA_LDLIBS=-lcudadevrt -lcudart_static $(LDLIBS)
 
-CUDA_LDFLAGS =-L$(LIBLOC)/lib -L${CUDA_HOME}/targets/x86_64-linux/lib/stubs -L${CUDA_HOME}/targets/x86_64-linux/lib
-CUDAFLAGS +=-std=c++17 -Xcompiler -fPIC --cudart static --relocatable-device-code=true --expt-relaxed-constexpr -gencode arch=compute_70,code=sm_70 -gencode arch=compute_75,code=sm_75
-ifdef GPU
-	CXXFLAGS += -DGPU_AVAILABLE
-	CUDAFLAGS += -gencode arch=compute_86,code=sm_86
-	CUDA_LDFLAGS += -L${CUDA_HOME}/lib64
-endif
+CUDA_LDFLAGS =-L$(LIBLOC)/lib -L${CUDA_HOME}/targets/x86_64-linux/lib/stubs -L${CUDA_HOME}/targets/x86_64-linux/lib -L${CUDA_HOME}/lib64
+CUDAFLAGS +=-std=c++17 -Xcompiler -fPIC --cudart static --relocatable-device-code=true --expt-relaxed-constexpr -gencode arch=compute_75,code=sm_75 -gencode arch=compute_86,code=sm_86 -gencode arch=compute_90,code=sm_90 -gencode arch=compute_100,code=sm_100
 
 PYTHON_LIB = pp_sketchlib$(shell python3-config --extension-suffix)
 

--- a/src/api.cpp
+++ b/src/api.cpp
@@ -7,6 +7,7 @@
 #include <algorithm>
 #include <limits>
 #include <queue>
+#include <string>
 
 #include <H5Cpp.h>
 #include <omp.h>
@@ -21,6 +22,24 @@
 
 using namespace Eigen;
 namespace py = pybind11;
+
+namespace {
+const float unfit_core_acc_distance = 1.0f;
+
+void warn_unfit_core_acc_distances(const size_t fallback_count) {
+  if (fallback_count == 0) {
+    return;
+  }
+
+  std::string message =
+      "Core/accessory distance regression failed for " +
+      std::to_string(fallback_count) +
+      " comparison(s); setting those distances to 1";
+  if (PyErr_WarnEx(PyExc_RuntimeWarning, message.c_str(), 1) != 0) {
+    throw py::error_already_set();
+  }
+}
+}
 
 bool same_db_version(const std::string &db1_name, const std::string &db2_name) {
   // Open databases
@@ -192,6 +211,7 @@ NumpyMatrix query_db(std::vector<Reference> &ref_sketches,
   // using a sort, except the return order of the distances wouldn't be as
   // expected. self iff ref_names == query_names as input
   bool interrupt = false;
+  size_t regression_fallbacks = 0;
   if (ref_sketches == query_sketches) {
     // calculate dists
     distMat.resize(dist_rows, dist_cols);
@@ -210,9 +230,16 @@ NumpyMatrix query_db(std::vector<Reference> &ref_sketches,
                   ref_sketches[j], kmer_lengths[kmer_idx], random_chance);
             }
           } else {
-            std::tie(distMat(pos, 0), distMat(pos, 1)) =
-                ref_sketches[i].core_acc_dist<RandomMC>(
-                    ref_sketches[j], kmer_mat, random_chance);
+            try {
+              std::tie(distMat(pos, 0), distMat(pos, 1)) =
+                  ref_sketches[i].core_acc_dist<RandomMC>(
+                      ref_sketches[j], kmer_mat, random_chance);
+            } catch (const RegressionFitError &) {
+              distMat(pos, 0) = unfit_core_acc_distance;
+              distMat(pos, 1) = unfit_core_acc_distance;
+#pragma omp atomic
+              ++regression_fallbacks;
+            }
           }
           if (pos % update_every == 0) {
 #pragma omp critical
@@ -262,9 +289,16 @@ NumpyMatrix query_db(std::vector<Reference> &ref_sketches,
             std::vector<double> jaccard_random = random_chance.random_matches(
                 ref_sketches[r_idx], query_random_idxs[q_idx],
                 query_lengths[q_idx], kmer_lengths);
-            std::tie(distMat(dist_row, 0), distMat(dist_row, 1)) =
-                query_sketches[q_idx].core_acc_dist<std::vector<double>>(
-                    ref_sketches[r_idx], kmer_mat, jaccard_random);
+            try {
+              std::tie(distMat(dist_row, 0), distMat(dist_row, 1)) =
+                  query_sketches[q_idx].core_acc_dist<std::vector<double>>(
+                      ref_sketches[r_idx], kmer_mat, jaccard_random);
+            } catch (const RegressionFitError &) {
+              distMat(dist_row, 0) = unfit_core_acc_distance;
+              distMat(dist_row, 1) = unfit_core_acc_distance;
+#pragma omp atomic
+              ++regression_fallbacks;
+            }
           }
           if ((q_idx * ref_sketches.size() + r_idx) % update_every == 0) {
 #pragma omp critical
@@ -286,6 +320,7 @@ NumpyMatrix query_db(std::vector<Reference> &ref_sketches,
     throw py::error_already_set();
   }
   dist_progress.finalise();
+  warn_unfit_core_acc_distances(regression_fallbacks);
 
   return (distMat);
 }
@@ -345,6 +380,7 @@ sparse_coo query_db_sparse(std::vector<Reference> &ref_sketches,
   std::vector<long> j_vec(ref_sketches.size() * kNN);
 
   bool interrupt = false;
+  size_t regression_fallbacks = 0;
 
   // Set up progress meter
   size_t dist_rows = static_cast<size_t>(ref_sketches.size() * ref_sketches.size());
@@ -371,13 +407,19 @@ sparse_coo query_db_sparse(std::vector<Reference> &ref_sketches,
                 ref_sketches[j], kmer_lengths[dist_col], random_chance);
           } else {
             float core, acc;
-            std::tie(core, acc) =
-                ref_sketches[i].core_acc_dist<RandomMC>(
-                    ref_sketches[j], kmer_mat, random_chance);
-            if (dist_col == 0) {
-              row_dist = core;
-            } else {
-              row_dist = acc;
+            try {
+              std::tie(core, acc) =
+                  ref_sketches[i].core_acc_dist<RandomMC>(
+                      ref_sketches[j], kmer_mat, random_chance);
+              if (dist_col == 0) {
+                row_dist = core;
+              } else {
+                row_dist = acc;
+              }
+            } catch (const RegressionFitError &) {
+              row_dist = unfit_core_acc_distance;
+#pragma omp atomic
+              ++regression_fallbacks;
             }
           }
         }
@@ -419,6 +461,7 @@ sparse_coo query_db_sparse(std::vector<Reference> &ref_sketches,
   if (interrupt) {
     throw py::error_already_set();
   }
+  warn_unfit_core_acc_distances(regression_fallbacks);
 
   // Revert to correct distance J = 1 - dist
   if (jaccard) {

--- a/src/dist/linear_regression.cpp
+++ b/src/dist/linear_regression.cpp
@@ -20,41 +20,36 @@ std::tuple<float, float> fit_slope(const Eigen::MatrixXf &kmers,
   // Store core/accessory in dists, truncating at zero
   float core_dist = 0, accessory_dist = 0;
   static const double tolerance = (5.0 / (r1->sketchsize64() * 64));
-  try {
-    Eigen::VectorXf slopes;
-    std::vector<int> valid;
-    for (int i = 0; i < dists.size(); ++i) {
-      if (dists(i) > tolerance) {
-        valid.push_back(i);
-      }
+  Eigen::VectorXf slopes;
+  std::vector<int> valid;
+  for (int i = 0; i < dists.size(); ++i) {
+    if (dists(i) > tolerance) {
+      valid.push_back(i);
     }
-    size_t valid_size = valid.back() - valid.front() + 1;
+  }
 
-    if (__builtin_expect(valid_size < 2, 0)) {
-      throw std::runtime_error("No non-zero Jaccard distances");
-    } else if (__builtin_expect(valid_size == dists.size(), 1)) {
-      // See https://eigen.tuxfamily.org/dox/group__LeastSquares.html
-      slopes = (kmers.transpose() * kmers).ldlt().solve(kmers.transpose() * (dists.array().log().matrix()));
-    } else {
-      size_t slice_start = valid.front();
-      Eigen::VectorXf dists_truncation = dists.segment(slice_start, valid_size);
-      Eigen::MatrixXf kmer_truncation = kmers.block(slice_start, 0, valid_size, 2);
-      slopes = (kmer_truncation.transpose() * kmer_truncation).ldlt().solve(kmer_truncation.transpose() * (dists_truncation.array().log().matrix()));
-    }
+  if (__builtin_expect(valid.empty(), 0)) {
+    throw RegressionFitError("No non-zero Jaccard distances");
+  }
+  size_t valid_size = valid.back() - valid.front() + 1;
 
-    if (slopes(1) < core_upper) {
-      core_dist = 1 - exp(slopes(1));
-    }
-    if (slopes(0) < accessory_upper) {
-      accessory_dist = 1 - exp(slopes(0));
-    }
-  } catch (const std::exception &e) {
-    std::cerr << e.what() << std::endl;
-    std::cerr << "Fitting k-mer gradient failed, for:" << r1->name() << "vs."
-              << r2->name() << std::endl;
-    std::cerr << dists << std::endl;
-    std::cerr << std::endl << "Check for low quality genomes" << std::endl;
-    exit(1);
+  if (__builtin_expect(valid_size < 2, 0)) {
+    throw RegressionFitError("Insufficient non-zero Jaccard distances");
+  } else if (__builtin_expect(valid_size == dists.size(), 1)) {
+    // See https://eigen.tuxfamily.org/dox/group__LeastSquares.html
+    slopes = (kmers.transpose() * kmers).ldlt().solve(kmers.transpose() * (dists.array().log().matrix()));
+  } else {
+    size_t slice_start = valid.front();
+    Eigen::VectorXf dists_truncation = dists.segment(slice_start, valid_size);
+    Eigen::MatrixXf kmer_truncation = kmers.block(slice_start, 0, valid_size, 2);
+    slopes = (kmer_truncation.transpose() * kmer_truncation).ldlt().solve(kmer_truncation.transpose() * (dists_truncation.array().log().matrix()));
+  }
+
+  if (slopes(1) < core_upper) {
+    core_dist = 1 - exp(slopes(1));
+  }
+  if (slopes(0) < accessory_upper) {
+    accessory_dist = 1 - exp(slopes(0));
   }
   return (std::make_tuple(core_dist, accessory_dist));
 }

--- a/src/reference.hpp
+++ b/src/reference.hpp
@@ -8,6 +8,7 @@
 
 #include <cstdint>
 #include <cstddef>
+#include <stdexcept>
 #include <vector>
 #include <string>
 #include <tuple>
@@ -21,6 +22,12 @@ const size_t def_sketchsize64 = 156;
 #include "sketch/sketch.hpp"
 
 class RandomMC;
+
+class RegressionFitError : public std::runtime_error {
+public:
+  explicit RegressionFitError(const std::string &message)
+      : std::runtime_error(message) {}
+};
 
 class Reference
 {


### PR DESCRIPTION
The dist length will segfault is empty (no non-zero dists)
Also error handling does not work properly for openmp & python library

Fix the handling of these cases by:
- Emitting a warning for number of failed dists at the end of loop
- Set failed dists to 1

Should be more reliable in a pipeline, and bad distances readily visible in the output